### PR TITLE
Remove focus state after closing menu

### DIFF
--- a/src/app/nav/gt-sm/gt-sm.component.html
+++ b/src/app/nav/gt-sm/gt-sm.component.html
@@ -1,11 +1,12 @@
 <mat-toolbar>
   <mat-toolbar-row class="nav-row">
     <button
-      mat-icon-button
       (click)="toggleSidenav()"
+      id="menu"
       fxLayoutGap="20px"
       fxShow="true"
       fxHide.gt-sm
+      mat-icon-button
     >
       <mat-icon>menu</mat-icon>
     </button>

--- a/src/app/nav/gt-sm/gt-sm.component.ts
+++ b/src/app/nav/gt-sm/gt-sm.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from "@angular/core";
+import { FocusMonitor } from "@angular/cdk/a11y";
+import { AfterViewInit, Component, OnInit } from "@angular/core";
 import { Router } from "@angular/router";
 import { SidenavService } from "src/app/nav/sidenav.service";
 
@@ -7,9 +8,16 @@ import { SidenavService } from "src/app/nav/sidenav.service";
   templateUrl: "./gt-sm.component.html",
   styleUrls: ["./gt-sm.component.scss"]
 })
-export class GtSmComponent implements OnInit {
-  constructor(private router: Router, private sidenavService: SidenavService) {}
+export class GtSmComponent implements AfterViewInit, OnInit {
+  constructor(
+    private focusMonitor: FocusMonitor,
+    private router: Router,
+    private sidenavService: SidenavService
+  ) {}
 
+  ngAfterViewInit() {
+    this.focusMonitor.stopMonitoring(document.getElementById("menu"));
+  }
   ngOnInit() {}
 
   isActive(): boolean {


### PR DESCRIPTION
When clicking on the burger menu and closing it, the focused state does not disappear automatically.

Resolves #2 