### PR TITLE
fix: upgrade libpng to address security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM nginx:alpine
+RUN apk upgrade --no-cache libpng
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY dist/apps/tehwolfde/browser /usr/share/nginx/html


### PR DESCRIPTION
## Summary

- Fixes CVE-2026-22695 (HIGH): Heap buffer over-read in libpng simplified API
- Fixes CVE-2026-22801 (HIGH): Integer truncation in simplified write API
- Upgrades libpng from 1.6.53-r0 to 1.6.54-r0 in Docker image

## Changes

Added `RUN apk upgrade --no-cache libpng` to Dockerfile to explicitly upgrade the libpng package in the nginx:alpine base image.

## Impact

This change only affects the Docker image base layer. It does not require any changes to package.json, npm dependencies, or application code. The vulnerabilities were identified by Trivy scanning the built container image.

## Test Plan

- [x] Dockerfile updated with libpng upgrade
- [ ] Build Docker image successfully
- [ ] Verify libpng version is 1.6.54-r0 or higher
- [ ] Run Trivy scan to confirm vulnerabilities are resolved
- [ ] Verify application runs correctly in container