### PR TITLE
refactor: remove redundant event_name input from workflow call

### DIFF
--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -25,7 +25,6 @@ jobs:
       e2e: "run e2e"
       build_branch: "run affected:build"
       build_main: "run build --skip-nx-cache"
-      event_name: ${{ github.event_name }}
       docker_pre: "[ -d ./dist/apps ] && mv -fv avatar* dist/apps/tehwolfde/browser/"
       docker_meta: '[{"name":"tehwolf.de","file":"Dockerfile"}]'
       libraries: "contact-form,git-portfolio,wordlist-generator"


### PR DESCRIPTION
## Summary
Removes redundant \`event_name: \${{ github.event_name }}\` input from the reusable workflow call.

\`github.event_name\` (and \`github.ref_name\`) are available directly in all reusable workflows — they don't need to be passed as inputs. Depends on tehw0lf/workflows#28.