### PR TITLE
feat(tehwolfde): add Numveil embed and open-in-new-tab link for embeds

### DIFF
--- a/apps/tehwolfde/src/app/app.routes.ts
+++ b/apps/tehwolfde/src/app/app.routes.ts
@@ -43,6 +43,11 @@ export const routes: Routes = [
       import('./flowdive/flowdive.component').then((m) => m.FlowdiveComponent)
   },
   {
+    path: 'numveil',
+    loadComponent: () =>
+      import('./numveil/numveil.component').then((m) => m.NumveilComponent)
+  },
+  {
     path: 'mutuals',
     loadComponent: () =>
       import('./mutuals/mutuals.component').then((m) => m.MutualsComponent)

--- a/apps/tehwolfde/src/app/embed/embed.component.html
+++ b/apps/tehwolfde/src/app/embed/embed.component.html
@@ -1,7 +1,20 @@
-<iframe
-  #iframe
-  [src]="safeUrl()"
-  class="embed-frame"
-  title="Embedded Tool"
-  (load)="onIframeLoad()"
-></iframe>
+<div class="embed-wrapper">
+  <div class="embed-toolbar">
+    <a
+      [href]="url()"
+      target="_blank"
+      rel="noopener noreferrer"
+      mat-icon-button
+      aria-label="Open in new tab"
+    >
+      <mat-icon>open_in_new</mat-icon>
+    </a>
+  </div>
+  <iframe
+    #iframe
+    [src]="safeUrl()"
+    class="embed-frame"
+    title="Embedded Tool"
+    (load)="onIframeLoad()"
+  ></iframe>
+</div>

--- a/apps/tehwolfde/src/app/embed/embed.component.scss
+++ b/apps/tehwolfde/src/app/embed/embed.component.scss
@@ -1,6 +1,19 @@
+.embed-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.embed-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  padding: 4px 8px;
+  flex-shrink: 0;
+}
+
 .embed-frame {
   border: none;
   width: 100%;
-  height: 100vh;
+  flex: 1;
   display: block;
 }

--- a/apps/tehwolfde/src/app/embed/embed.component.ts
+++ b/apps/tehwolfde/src/app/embed/embed.component.ts
@@ -9,6 +9,8 @@ import {
   ViewChild
 } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
+import { MatIconButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
 
 import { ThemeService } from '../theme.service';
 
@@ -17,6 +19,7 @@ import { ThemeService } from '../theme.service';
   templateUrl: './embed.component.html',
   styleUrl: './embed.component.scss',
   standalone: true,
+  imports: [MatIconButton, MatIcon],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EmbedComponent {

--- a/apps/tehwolfde/src/app/nav/desktop/desktop.component.html
+++ b/apps/tehwolfde/src/app/nav/desktop/desktop.component.html
@@ -57,6 +57,12 @@
           </span>
         </a>
       </div><div class="nav-item flex-gap-20">
+        <a mat-button routerLink="/numveil" routerLinkActive="link-active">
+          <span class="mat-button-wrapper">
+            <span>Numveil</span>
+          </span>
+        </a>
+      </div><div class="nav-item flex-gap-20">
         <a mat-button routerLink="/beep" routerLinkActive="link-active">
           <span class="mat-button-wrapper">
             <span>Beep</span>

--- a/apps/tehwolfde/src/app/nav/mobile/mobile.component.html
+++ b/apps/tehwolfde/src/app/nav/mobile/mobile.component.html
@@ -57,6 +57,11 @@
           <span>Flowdive</span>
         </span>
       </a>
+      <a (click)="closeSidenav()" routerLink="/numveil" routerLinkActive="link-active" mat-list-item>
+        <span>
+          <span>Numveil</span>
+        </span>
+      </a>
       <a (click)="closeSidenav()" routerLink="/beep" routerLinkActive="link-active" mat-list-item>
         <span>
           <span>Beep</span>

--- a/apps/tehwolfde/src/app/numveil/numveil.component.ts
+++ b/apps/tehwolfde/src/app/numveil/numveil.component.ts
@@ -1,0 +1,12 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import { EmbedComponent } from '../embed/embed.component';
+
+@Component({
+  selector: 'tehw0lf-numveil',
+  standalone: true,
+  imports: [EmbedComponent],
+  template: `<tehw0lf-embed url="https://numveil.tehwolf.de" />`,
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class NumveilComponent {}


### PR DESCRIPTION
## Summary

- Add `NumveilComponent` that embeds `https://numveil.tehwolf.de` via the existing `EmbedComponent`
- Add `/numveil` route and nav links in both desktop and mobile navigation
- Add `open_in_new` icon button toolbar to `EmbedComponent` — opens the embedded app in a new tab (applies to Flowdive and Numveil)

## Test plan

- [ ] `/numveil` route renders the Numveil embed
- [ ] Nav link appears in desktop and mobile nav
- [ ] `open_in_new` button in toolbar opens the correct URL in a new tab
- [ ] Flowdive embed still works and also shows the external link button
- [ ] Lint, tests and build pass ✅