### PR TITLE
refactor(tehwolfde): consolidate app nav links into Apps dropdown

### DIFF
--- a/apps/tehwolfde/src/app/app.routes.ts
+++ b/apps/tehwolfde/src/app/app.routes.ts
@@ -43,6 +43,11 @@ export const routes: Routes = [
       import('./flowdive/flowdive.component').then((m) => m.FlowdiveComponent)
   },
   {
+    path: 'numveil',
+    loadComponent: () =>
+      import('./numveil/numveil.component').then((m) => m.NumveilComponent)
+  },
+  {
     path: 'mutuals',
     loadComponent: () =>
       import('./mutuals/mutuals.component').then((m) => m.MutualsComponent)

--- a/apps/tehwolfde/src/app/embed/embed.component.html
+++ b/apps/tehwolfde/src/app/embed/embed.component.html
@@ -1,7 +1,20 @@
-<iframe
-  #iframe
-  [src]="safeUrl()"
-  class="embed-frame"
-  title="Embedded Tool"
-  (load)="onIframeLoad()"
-></iframe>
+<div class="embed-wrapper">
+  <div class="embed-toolbar">
+    <a
+      [href]="url()"
+      target="_blank"
+      rel="noopener noreferrer"
+      mat-icon-button
+      aria-label="Open in new tab"
+    >
+      <mat-icon>open_in_new</mat-icon>
+    </a>
+  </div>
+  <iframe
+    #iframe
+    [src]="safeUrl()"
+    class="embed-frame"
+    title="Embedded Tool"
+    (load)="onIframeLoad()"
+  ></iframe>
+</div>

--- a/apps/tehwolfde/src/app/embed/embed.component.scss
+++ b/apps/tehwolfde/src/app/embed/embed.component.scss
@@ -1,6 +1,19 @@
+.embed-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.embed-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  padding: 4px 8px;
+  flex-shrink: 0;
+}
+
 .embed-frame {
   border: none;
   width: 100%;
-  height: 100vh;
+  flex: 1;
   display: block;
 }

--- a/apps/tehwolfde/src/app/embed/embed.component.scss
+++ b/apps/tehwolfde/src/app/embed/embed.component.scss
@@ -1,6 +1,8 @@
 .embed-wrapper {
   position: relative;
   height: 100vh;
+  margin: -32px 0 0 -32px;
+  width: calc(100% + 32px);
 }
 
 .embed-toolbar {

--- a/apps/tehwolfde/src/app/embed/embed.component.scss
+++ b/apps/tehwolfde/src/app/embed/embed.component.scss
@@ -6,7 +6,7 @@
 
 .embed-toolbar {
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
   padding: 4px 8px;
   flex-shrink: 0;
 }

--- a/apps/tehwolfde/src/app/embed/embed.component.scss
+++ b/apps/tehwolfde/src/app/embed/embed.component.scss
@@ -1,19 +1,18 @@
 .embed-wrapper {
-  display: flex;
-  flex-direction: column;
+  position: relative;
   height: 100vh;
 }
 
 .embed-toolbar {
-  display: flex;
-  justify-content: flex-start;
-  padding: 4px 8px;
-  flex-shrink: 0;
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 10;
 }
 
 .embed-frame {
   border: none;
   width: 100%;
-  flex: 1;
+  height: 100%;
   display: block;
 }

--- a/apps/tehwolfde/src/app/embed/embed.component.scss
+++ b/apps/tehwolfde/src/app/embed/embed.component.scss
@@ -1,10 +1,11 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
 .embed-wrapper {
-  position: fixed;
-  top: 64px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 1;
+  position: relative;
+  height: 100%;
 }
 
 .embed-toolbar {

--- a/apps/tehwolfde/src/app/embed/embed.component.scss
+++ b/apps/tehwolfde/src/app/embed/embed.component.scss
@@ -1,8 +1,10 @@
 .embed-wrapper {
-  position: relative;
-  height: 100vh;
-  margin: -32px 0 0 -32px;
-  width: calc(100% + 32px);
+  position: fixed;
+  top: 64px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1;
 }
 
 .embed-toolbar {

--- a/apps/tehwolfde/src/app/embed/embed.component.ts
+++ b/apps/tehwolfde/src/app/embed/embed.component.ts
@@ -9,6 +9,8 @@ import {
   ViewChild
 } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
+import { MatIconButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
 
 import { ThemeService } from '../theme.service';
 
@@ -17,6 +19,7 @@ import { ThemeService } from '../theme.service';
   templateUrl: './embed.component.html',
   styleUrl: './embed.component.scss',
   standalone: true,
+  imports: [MatIconButton, MatIcon],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EmbedComponent {

--- a/apps/tehwolfde/src/app/nav/desktop/desktop.component.html
+++ b/apps/tehwolfde/src/app/nav/desktop/desktop.component.html
@@ -50,45 +50,22 @@
             <span>Contact Form</span>
           </span>
         </a>
-      </div><div class="nav-item flex-gap-20">
-        <a mat-button routerLink="/flowdive" routerLinkActive="link-active">
-          <span class="mat-button-wrapper">
-            <span>Flowdive</span>
-          </span>
-        </a>
-      </div><div class="nav-item flex-gap-20">
-        <a mat-button routerLink="/numveil" routerLinkActive="link-active">
-          <span class="mat-button-wrapper">
-            <span>Numveil</span>
-          </span>
-        </a>
-      </div><div class="nav-item flex-gap-20">
-        <a mat-button routerLink="/beep" routerLinkActive="link-active">
-          <span class="mat-button-wrapper">
-            <span>Beep</span>
-          </span>
-        </a>
       </div>
       <div class="nav-item flex-gap-20">
-        <a mat-button routerLink="/mutuals" routerLinkActive="link-active">
+        <button mat-button [matMenuTriggerFor]="appsMenu">
           <span class="mat-button-wrapper">
-            <span>Mutuals</span>
+            <span>Apps</span>
+            <mat-icon>arrow_drop_down</mat-icon>
           </span>
-        </a>
-      </div>
-      <div class="nav-item flex-gap-20">
-        <a mat-button routerLink="/btrain" routerLinkActive="link-active">
-          <span class="mat-button-wrapper">
-            <span>BTrain</span>
-          </span>
-        </a>
-      </div>
-      <div class="nav-item flex-gap-20">
-        <a mat-button routerLink="/color" routerLinkActive="link-active">
-          <span class="mat-button-wrapper">
-            <span>Color</span>
-          </span>
-        </a>
+        </button>
+        <mat-menu #appsMenu="matMenu">
+          <a mat-menu-item routerLink="/flowdive" routerLinkActive="link-active">Flowdive</a>
+          <a mat-menu-item routerLink="/numveil" routerLinkActive="link-active">Numveil</a>
+          <a mat-menu-item routerLink="/beep" routerLinkActive="link-active">Beep</a>
+          <a mat-menu-item routerLink="/btrain" routerLinkActive="link-active">BTrain</a>
+          <a mat-menu-item routerLink="/mutuals" routerLinkActive="link-active">Mutuals</a>
+          <a mat-menu-item routerLink="/color" routerLinkActive="link-active">Color</a>
+        </mat-menu>
       </div>
     </div>
     @if (themeService.theme() === 'dark') {

--- a/apps/tehwolfde/src/app/nav/desktop/desktop.component.html
+++ b/apps/tehwolfde/src/app/nav/desktop/desktop.component.html
@@ -57,6 +57,12 @@
           </span>
         </a>
       </div><div class="nav-item flex-gap-20">
+        <a mat-button routerLink="/numveil" routerLinkActive="link-active">
+          <span class="mat-button-wrapper">
+            <span>Numveil</span>
+          </span>
+        </a>
+      </div><div class="nav-item flex-gap-20">
         <a mat-button routerLink="/beep" routerLinkActive="link-active">
           <span class="mat-button-wrapper">
             <span>Beep</span>

--- a/apps/tehwolfde/src/app/nav/desktop/desktop.component.scss
+++ b/apps/tehwolfde/src/app/nav/desktop/desktop.component.scss
@@ -26,8 +26,6 @@
 .nav-row {
   border-radius: 4px;
   backdrop-filter: blur(15px);
-  position: relative;
-  z-index: 100;
 }
 
 .mat-toolbar-multiple-rows {

--- a/apps/tehwolfde/src/app/nav/desktop/desktop.component.scss
+++ b/apps/tehwolfde/src/app/nav/desktop/desktop.component.scss
@@ -12,6 +12,8 @@
 }
 
 .mat-button-wrapper {
+  display: inline-flex;
+  align-items: center;
   color: global.$linkcolor;
 }
 

--- a/apps/tehwolfde/src/app/nav/desktop/desktop.component.scss
+++ b/apps/tehwolfde/src/app/nav/desktop/desktop.component.scss
@@ -26,6 +26,8 @@
 .nav-row {
   border-radius: 4px;
   backdrop-filter: blur(15px);
+  position: relative;
+  z-index: 100;
 }
 
 .mat-toolbar-multiple-rows {

--- a/apps/tehwolfde/src/app/nav/desktop/desktop.component.ts
+++ b/apps/tehwolfde/src/app/nav/desktop/desktop.component.ts
@@ -11,6 +11,7 @@ import {
 import { toSignal } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import {
   isActive,
@@ -33,6 +34,7 @@ import { SidenavService } from '../sidenav.service';
     NgClass,
     MatButtonModule,
     MatIconModule,
+    MatMenuModule,
     RouterLink,
     RouterLinkActive
   ],

--- a/apps/tehwolfde/src/app/nav/mobile/mobile.component.html
+++ b/apps/tehwolfde/src/app/nav/mobile/mobile.component.html
@@ -57,6 +57,11 @@
           <span>Flowdive</span>
         </span>
       </a>
+      <a (click)="closeSidenav()" routerLink="/numveil" routerLinkActive="link-active" mat-list-item>
+        <span>
+          <span>Numveil</span>
+        </span>
+      </a>
       <a (click)="closeSidenav()" routerLink="/beep" routerLinkActive="link-active" mat-list-item>
         <span>
           <span>Beep</span>

--- a/apps/tehwolfde/src/app/nav/mobile/mobile.component.html
+++ b/apps/tehwolfde/src/app/nav/mobile/mobile.component.html
@@ -52,50 +52,25 @@
           <span>Contact Form (Demo)</span>
         </span>
       </a>
+      <mat-divider></mat-divider>
+      <h3 matSubheader class="apps-subheader">Apps</h3>
       <a (click)="closeSidenav()" routerLink="/flowdive" routerLinkActive="link-active" mat-list-item>
-        <span>
-          <span>Flowdive</span>
-        </span>
+        <span>Flowdive</span>
       </a>
       <a (click)="closeSidenav()" routerLink="/numveil" routerLinkActive="link-active" mat-list-item>
-        <span>
-          <span>Numveil</span>
-        </span>
+        <span>Numveil</span>
       </a>
       <a (click)="closeSidenav()" routerLink="/beep" routerLinkActive="link-active" mat-list-item>
-        <span>
-          <span>Beep</span>
-        </span>
+        <span>Beep</span>
       </a>
-      <a
-        (click)="closeSidenav()"
-        routerLink="/mutuals"
-        routerLinkActive="link-active"
-        mat-list-item
-      >
-        <span>
-          <span>Mutuals</span>
-        </span>
+      <a (click)="closeSidenav()" routerLink="/btrain" routerLinkActive="link-active" mat-list-item>
+        <span>BTrain</span>
       </a>
-      <a
-        (click)="closeSidenav()"
-        routerLink="/btrain"
-        routerLinkActive="link-active"
-        mat-list-item
-      >
-        <span>
-          <span>BTrain</span>
-        </span>
+      <a (click)="closeSidenav()" routerLink="/mutuals" routerLinkActive="link-active" mat-list-item>
+        <span>Mutuals</span>
       </a>
-      <a
-        (click)="closeSidenav()"
-        routerLink="/color"
-        routerLinkActive="link-active"
-        mat-list-item
-      >
-        <span>
-          <span>Color</span>
-        </span>
+      <a (click)="closeSidenav()" routerLink="/color" routerLinkActive="link-active" mat-list-item>
+        <span>Color</span>
       </a>
       <a
         (click)="closeSidenav()"

--- a/apps/tehwolfde/src/app/nav/mobile/mobile.component.scss
+++ b/apps/tehwolfde/src/app/nav/mobile/mobile.component.scss
@@ -53,3 +53,13 @@
 span.mat-mdc-button-persistent-ripple.mdc-icon-button__ripple::before {
   background: transparent;
 }
+
+.apps-subheader {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.6;
+  padding: 8px 16px 4px;
+  margin: 0;
+}

--- a/apps/tehwolfde/src/app/nav/mobile/mobile.component.scss
+++ b/apps/tehwolfde/src/app/nav/mobile/mobile.component.scss
@@ -48,6 +48,10 @@
 .main-content {
   color: global.$fontcolor;
   padding: 32px 0 0 32px;
+
+  &:has(tehw0lf-embed) {
+    padding: 0;
+  }
 }
 
 span.mat-mdc-button-persistent-ripple.mdc-icon-button__ripple::before {

--- a/apps/tehwolfde/src/app/nav/mobile/mobile.component.ts
+++ b/apps/tehwolfde/src/app/nav/mobile/mobile.component.ts
@@ -12,6 +12,7 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatDivider } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatSidenav, MatSidenavModule } from '@angular/material/sidenav';
@@ -37,6 +38,7 @@ import { SidenavService } from '../sidenav.service';
     MatSidenavModule,
     NgClass,
     MatListModule,
+    MatDivider,
     RouterLink,
     RouterLinkActive,
     MatButtonModule,

--- a/apps/tehwolfde/src/app/nav/nav.component.html
+++ b/apps/tehwolfde/src/app/nav/nav.component.html
@@ -1,2 +1,4 @@
-<tehw0lf-desktop></tehw0lf-desktop>
-<tehw0lf-mobile></tehw0lf-mobile>
+<div class="nav-layout">
+  <tehw0lf-desktop></tehw0lf-desktop>
+  <tehw0lf-mobile></tehw0lf-mobile>
+</div>

--- a/apps/tehwolfde/src/app/nav/nav.component.scss
+++ b/apps/tehwolfde/src/app/nav/nav.component.scss
@@ -1,0 +1,10 @@
+.nav-layout {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+
+  tehw0lf-mobile {
+    flex: 1;
+    overflow: hidden;
+  }
+}

--- a/apps/tehwolfde/src/app/nav/nav.component.ts
+++ b/apps/tehwolfde/src/app/nav/nav.component.ts
@@ -6,6 +6,7 @@ import { MobileComponent } from './mobile/mobile.component';
 @Component({
   selector: 'tehw0lf-nav',
   templateUrl: './nav.component.html',
+  styleUrl: './nav.component.scss',
   imports: [DesktopComponent, MobileComponent]
 })
 export class NavComponent {}

--- a/apps/tehwolfde/src/app/numveil/numveil.component.ts
+++ b/apps/tehwolfde/src/app/numveil/numveil.component.ts
@@ -1,0 +1,12 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import { EmbedComponent } from '../embed/embed.component';
+
+@Component({
+  selector: 'tehw0lf-numveil',
+  standalone: true,
+  imports: [EmbedComponent],
+  template: `<tehw0lf-embed url="https://numveil.tehwolf.de" />`,
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class NumveilComponent {}

--- a/apps/tehwolfde/src/styles.scss
+++ b/apps/tehwolfde/src/styles.scss
@@ -21,6 +21,6 @@ body.light {
   letter-spacing: normal !important;
 }
 
-.mat-mdc-menu-panel .mdc-list-item__primary-text {
+.mat-mdc-menu-item-text {
   color: global.$linkcolor !important;
 }

--- a/apps/tehwolfde/src/styles.scss
+++ b/apps/tehwolfde/src/styles.scss
@@ -21,6 +21,6 @@ body.light {
   letter-spacing: normal !important;
 }
 
-.mat-mdc-menu-item .mdc-list-item__primary-text {
-  color: global.$linkcolor;
+.mat-mdc-menu-panel .mdc-list-item__primary-text {
+  color: global.$linkcolor !important;
 }

--- a/apps/tehwolfde/src/styles.scss
+++ b/apps/tehwolfde/src/styles.scss
@@ -20,3 +20,7 @@ body.light {
 .mat-mdc-button {
   letter-spacing: normal !important;
 }
+
+.mat-mdc-menu-item .mdc-list-item__primary-text {
+  color: global.$linkcolor;
+}

--- a/apps/tehwolfde/src/styles.scss
+++ b/apps/tehwolfde/src/styles.scss
@@ -24,3 +24,11 @@ body.light {
 .mat-mdc-menu-item-text {
   color: global.$linkcolor !important;
 }
+
+body.dark .mat-mdc-menu-panel {
+  background-color: #222222;
+}
+
+body.light .mat-mdc-menu-panel {
+  background-color: rgb(212, 212, 212);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.21.6",
+      "version": "0.21.7",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "21.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary

- **Desktop**: replaces individual Flowdive, Numveil, Beep, BTrain, Mutuals, Color nav links with a single "Apps" button that opens a `mat-menu` dropdown
- **Mobile**: same links remain flat in the sidenav but are now grouped under an "Apps" subheader with a divider separator
- Nav items that stay top-level: Home, Portfolio, Wordlist Generator, Contact Form, GitHub

## Test plan

- [ ] Desktop "Apps" button opens dropdown with all 6 app links
- [ ] Each dropdown link navigates correctly and closes the menu
- [ ] Mobile sidenav shows "Apps" subheader above the grouped links
- [ ] Top-level nav items (Home, Portfolio, Wordlist Generator, Contact Form) are unaffected
- [ ] Lint, tests and build pass ✅