### PR TITLE
feat(home): add library showcase with live iframe previews

### DIFF
--- a/apps/tehwolfde/src/app/home/home.component.html
+++ b/apps/tehwolfde/src/app/home/home.component.html
@@ -1,1 +1,28 @@
-<h1 class="mat-headline-5">Welcome to tehwolf.de!</h1>
+<div class="home-container">
+  <h1 class="mat-headline-5">Welcome to tehwolf.de!</h1>
+  <div class="library-grid">
+    @for (lib of libraries; track lib.route) {
+      <mat-card [ngStyle]="cardStyle()">
+        <mat-card-header>
+          <mat-card-title>{{ lib.title }}</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <div class="preview-container">
+            <iframe
+              [src]="lib.previewUrl"
+              class="preview-iframe"
+              tabindex="-1"
+              aria-hidden="true"
+            ></iframe>
+          </div>
+          <p class="description">{{ lib.description }}</p>
+        </mat-card-content>
+        <mat-card-actions>
+          <a mat-button [ngStyle]="buttonStyle()" [routerLink]="lib.route">
+            Try it
+          </a>
+        </mat-card-actions>
+      </mat-card>
+    }
+  </div>
+</div>

--- a/apps/tehwolfde/src/app/home/home.component.scss
+++ b/apps/tehwolfde/src/app/home/home.component.scss
@@ -1,0 +1,32 @@
+.home-container {
+  padding: 16px;
+}
+
+.library-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+  margin-top: 24px;
+}
+
+.preview-container {
+  position: relative;
+  width: 100%;
+  height: 240px;
+  overflow: hidden;
+  border-radius: 4px;
+  margin-bottom: 12px;
+  pointer-events: none;
+
+  .preview-iframe {
+    width: 200%;
+    height: 200%;
+    border: none;
+    transform: scale(0.5);
+    transform-origin: top left;
+  }
+}
+
+.description {
+  margin: 0;
+}

--- a/apps/tehwolfde/src/app/home/home.component.spec.ts
+++ b/apps/tehwolfde/src/app/home/home.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 
 import { HomeComponent } from './home.component';
 
@@ -8,7 +9,8 @@ describe('HomeComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HomeComponent]
+      imports: [HomeComponent],
+      providers: [provideRouter([])]
     }).compileComponents();
   });
 

--- a/apps/tehwolfde/src/app/home/home.component.ts
+++ b/apps/tehwolfde/src/app/home/home.component.ts
@@ -1,9 +1,64 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { NgStyle } from '@angular/common';
+
+import { ThemeService } from '../theme.service';
+
+interface LibraryCard {
+  title: string;
+  description: string;
+  route: string;
+  previewUrl: SafeResourceUrl;
+}
 
 @Component({
   selector: 'tehw0lf-home',
   templateUrl: './home.component.html',
+  styleUrls: ['./home.component.scss'],
   standalone: true,
+  imports: [RouterLink, MatButtonModule, MatCardModule, NgStyle],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class HomeComponent {}
+export class HomeComponent {
+  private themeService = inject(ThemeService);
+  private sanitizer = inject(DomSanitizer);
+
+  libraries: LibraryCard[] = [
+    {
+      title: 'git-portfolio',
+      description: 'Customizable Git repository portfolio supporting GitHub and GitLab. Displays repos with stats, language colors, and links.',
+      route: '/portfolio',
+      previewUrl: this.sanitizer.bypassSecurityTrustResourceUrl('/portfolio')
+    },
+    {
+      title: 'wordlist-generator',
+      description: 'Cartesian product-based wordlist generator with drag-and-drop charset management and multiple export formats.',
+      route: '/wordlist-generator',
+      previewUrl: this.sanitizer.bypassSecurityTrustResourceUrl('/wordlist-generator')
+    },
+    {
+      title: 'contact-form',
+      description: 'Flexible contact form built with ngx-formly. Supports dynamic fields, validation, and custom API callbacks.',
+      route: '/contact-form',
+      previewUrl: this.sanitizer.bypassSecurityTrustResourceUrl('/contact-form')
+    }
+  ];
+
+  cardStyle = computed(() => ({
+    'background-color': this.themeService.theme() === 'dark'
+      ? 'rgba(34, 34, 34, 0.75)'
+      : 'rgba(255, 255, 255, 0.75)',
+    'backdrop-filter': 'blur(50px)',
+    color: '#437da8'
+  }));
+
+  buttonStyle = computed(() => ({
+    'background-color': this.themeService.theme() === 'dark'
+      ? '#333333'
+      : 'rgba(255, 255, 255, 0.75)',
+    color: '#cc7832'
+  }));
+}

--- a/libs/contact-form/package.json
+++ b/libs/contact-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tehw0lf/contact-form",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "license": "MIT",
   "homepage": "https://github.com/tehw0lf/tehwol.fi.git",
   "repository": {

--- a/libs/git-portfolio/package.json
+++ b/libs/git-portfolio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tehw0lf/git-portfolio",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "license": "MIT",
   "homepage": "https://github.com/tehw0lf/tehwol.fi.git",
   "repository": {

--- a/libs/git-portfolio/src/lib/repo-card/repo-card.component.html
+++ b/libs/git-portfolio/src/lib/repo-card/repo-card.component.html
@@ -16,7 +16,7 @@
         mat-button
         [ngStyle]="buttonStyle()"
         target="_blank"
-        href="{{ gitRepo().html_url || gitRepo().web_url }}"
+        href="{{ gitRepo().homepage || gitRepo().html_url || gitRepo().web_url }}"
       >
         {{ gitRepo().name }}
       </a>
@@ -100,7 +100,7 @@
             width="24px"
             class="flex-gap-5"
           ></div>
-          <span>Copy URL</span>
+          <span>Copy repo URL</span>
         </span>
       </button>
     </span>

--- a/libs/git-portfolio/src/lib/types/git-repository-type.ts
+++ b/libs/git-portfolio/src/lib/types/git-repository-type.ts
@@ -6,6 +6,7 @@ export class GitRepository {
   description: string | undefined;
   fork?: boolean;
   forks_count: number | undefined;
+  homepage?: string;
   html_url?: string;
   web_url?: string;
   language?: string;

--- a/libs/wordlist-generator/package.json
+++ b/libs/wordlist-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tehw0lf/wordlist-generator",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "license": "MIT",
   "homepage": "https://github.com/tehw0lf/tehwol.fi.git",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.21.8",
+  "version": "0.21.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.21.8",
+      "version": "0.21.9",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "21.2.8",
@@ -19132,9 +19132,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.21.8",
+  "version": "0.21.9",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary
- Add interactive showcase cards on home tab for git-portfolio, wordlist-generator, and contact-form libraries
- Each card shows a scaled live iframe preview of the actual route, plus description and "Try it" navigation link
- Add `homepage` field to `GitRepository` DTO so repo cards link to deployed site with `html_url` as fallback
- Rename "Copy URL" to "Copy repo URL" for UX clarity

## Test plan
- [ ] Home tab shows 3 library cards with live previews
- [ ] "Try it" navigates to the correct route
- [ ] git-portfolio repo cards with a homepage URL open the deployed site, others open the GitHub repo
- [ ] "Copy repo URL" button copies the clone URL as before
- [ ] All tests pass