### PR TITLE
fix(home): fix symmetric padding on home showcase and main content

### DIFF
--- a/apps/tehwolfde/src/app/home/home.component.html
+++ b/apps/tehwolfde/src/app/home/home.component.html
@@ -1,4 +1,4 @@
-<div class="home-container">
+<div>
   <h1 class="mat-headline-5">Welcome to tehwolf.de!</h1>
   <div class="library-grid">
     @for (lib of libraries; track lib.route) {

--- a/apps/tehwolfde/src/app/home/home.component.scss
+++ b/apps/tehwolfde/src/app/home/home.component.scss
@@ -1,7 +1,3 @@
-.home-container {
-  padding: 16px;
-}
-
 .library-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));

--- a/apps/tehwolfde/src/app/nav/mobile/mobile.component.scss
+++ b/apps/tehwolfde/src/app/nav/mobile/mobile.component.scss
@@ -47,7 +47,8 @@
 
 .main-content {
   color: global.$fontcolor;
-  padding: 32px 0 0 32px;
+  padding: 16px;
+  box-sizing: border-box;
 
   &:has(tehw0lf-embed) {
     padding: 0;

--- a/libs/git-portfolio/package.json
+++ b/libs/git-portfolio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tehw0lf/git-portfolio",
-  "version": "0.21.7",
+  "version": "0.21.8",
   "license": "MIT",
   "homepage": "https://github.com/tehw0lf/tehwol.fi.git",
   "repository": {

--- a/libs/git-portfolio/src/lib/git-portfolio.component.html
+++ b/libs/git-portfolio/src/lib/git-portfolio.component.html
@@ -3,7 +3,7 @@
     @for (gitProvider of gitProviders | keyvalue; track gitProvider) {
       @if (hasAnyRepositories(gitRepositories, gitProvider.key)) {
         <div>
-          <h1 [ngStyle]="textStyle()">{{ gitProvider.value }}</h1>
+          <h1 [ngStyle]="textStyle()" class="mat-headline">{{ gitProvider.value }}</h1>
           @if (showOwn()) {
             <div>
               <h2 [ngStyle]="textStyle()" class="mat-headline">Own Repos</h2>

--- a/libs/git-portfolio/src/lib/git-portfolio.component.scss
+++ b/libs/git-portfolio/src/lib/git-portfolio.component.scss
@@ -9,4 +9,5 @@
   font-weight: 400;
   line-height: 32px;
   margin-bottom: 16px;
+  margin-top: 0;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.21.9",
+  "version": "0.21.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.21.9",
+      "version": "0.21.10",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "21.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.21.9",
+  "version": "0.21.10",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary
- Add `box-sizing: border-box` to `.main-content` so `padding: 16px` applies correctly on all sides within `mat-sidenav-content`
- Reduce padding from 32px to 16px for a tighter, more balanced layout

## Test plan
- [ ] Home tab cards have equal padding on all sides
- [ ] Other routes unaffected
- [ ] Mobile layout looks correct