### PR TITLE
fix(a11y): improve accessibility

### DIFF
--- a/apps/tehwolfde-e2e/src/wordlist-generator.spec.ts
+++ b/apps/tehwolfde-e2e/src/wordlist-generator.spec.ts
@@ -29,7 +29,8 @@ test.describe('Wordlist Generator Page', () => {
     if ((await addButton.count()) > 0) {
       await addButton.first().click();
 
-      // Verify new input was added
+      // Wait for new input to appear, then verify count increased
+      await expect(charsetInputs.nth(initialInputs)).toBeVisible();
       const newInputs = await charsetInputs.count();
       expect(newInputs).toBeGreaterThan(initialInputs);
     }

--- a/apps/tehwolfde/src/app/app.component.ts
+++ b/apps/tehwolfde/src/app/app.component.ts
@@ -1,5 +1,7 @@
 import { NgClass } from '@angular/common';
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { filter } from 'rxjs';
 
 import { NavComponent } from './components/nav/nav.component';
 import { ThemeService } from './services/theme.service';
@@ -12,4 +14,14 @@ import { ThemeService } from './services/theme.service';
 })
 export class AppComponent {
   themeService = inject(ThemeService);
+
+  constructor() {
+    const router = inject(Router);
+    router.events
+      .pipe(filter((e) => e instanceof NavigationEnd))
+      .subscribe(() => {
+        const main = document.getElementById('main-content');
+        main?.focus();
+      });
+  }
 }

--- a/apps/tehwolfde/src/app/components/nav/mobile/mobile.component.html
+++ b/apps/tehwolfde/src/app/components/nav/mobile/mobile.component.html
@@ -130,6 +130,7 @@
     class="main-content flex-fxflex-fill"
     (click)="closeSidenav()"
   >
+    <span id="main-content" tabindex="-1"></span>
     <router-outlet></router-outlet>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/apps/tehwolfde/src/app/embeds/beep/beep.component.ts
+++ b/apps/tehwolfde/src/app/embeds/beep/beep.component.ts
@@ -6,7 +6,7 @@ import { EmbedComponent } from '../embed/embed.component';
   selector: 'tehw0lf-beep',
   standalone: true,
   imports: [EmbedComponent],
-  template: `<tehw0lf-embed url="https://tehw0lf.github.io/beep/" />`,
+  template: `<tehw0lf-embed url="https://tehw0lf.github.io/beep/" title="Beep Simulator" />`,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class BeepSimulatorComponent {}

--- a/apps/tehwolfde/src/app/embeds/btrain/btrain.component.ts
+++ b/apps/tehwolfde/src/app/embeds/btrain/btrain.component.ts
@@ -6,7 +6,7 @@ import { EmbedComponent } from '../embed/embed.component';
   selector: 'tehw0lf-btrain',
   standalone: true,
   imports: [EmbedComponent],
-  template: `<tehw0lf-embed url="https://btrain.tehwolf.de" />`,
+  template: `<tehw0lf-embed url="https://btrain.tehwolf.de" title="BTrain" />`,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class BtrainComponent {}

--- a/apps/tehwolfde/src/app/embeds/color/color.component.html
+++ b/apps/tehwolfde/src/app/embeds/color/color.component.html
@@ -1,5 +1,6 @@
 <div class="color-controls">
   <mat-form-field appearance="outline">
+    <mat-label>Color value</mat-label>
     <input
       matInput
       [ngModel]="inputValue()"
@@ -13,6 +14,7 @@
     [value]="hexColor()"
     (input)="inputValue.set($any($event.target).value); apply()"
     class="color-picker"
+    aria-label="Color picker"
   />
 </div>
-<tehw0lf-embed [url]="iframeUrl()" />
+<tehw0lf-embed [url]="iframeUrl()" title="Color" />

--- a/apps/tehwolfde/src/app/embeds/embed/embed.component.html
+++ b/apps/tehwolfde/src/app/embeds/embed/embed.component.html
@@ -14,7 +14,7 @@
     #iframe
     [src]="safeUrl()"
     class="embed-frame"
-    title="Embedded Tool"
+    [title]="title()"
     (load)="onIframeLoad()"
   ></iframe>
 </div>

--- a/apps/tehwolfde/src/app/embeds/embed/embed.component.ts
+++ b/apps/tehwolfde/src/app/embeds/embed/embed.component.ts
@@ -15,6 +15,7 @@ import { ThemeService } from '../../services/theme.service';
 })
 export class EmbedComponent {
   url = input.required<string>();
+  title = input('Embedded Tool');
 
   @ViewChild('iframe') private iframeRef:
     | ElementRef<HTMLIFrameElement>

--- a/apps/tehwolfde/src/app/embeds/flowdive/flowdive.component.ts
+++ b/apps/tehwolfde/src/app/embeds/flowdive/flowdive.component.ts
@@ -6,7 +6,7 @@ import { EmbedComponent } from '../embed/embed.component';
   selector: 'tehw0lf-flowdive',
   standalone: true,
   imports: [EmbedComponent],
-  template: `<tehw0lf-embed url="https://flowdive.tehwolf.de" />`,
+  template: `<tehw0lf-embed url="https://flowdive.tehwolf.de" title="Flowdive" />`,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FlowdiveComponent {}

--- a/apps/tehwolfde/src/app/embeds/mutuals/mutuals.component.ts
+++ b/apps/tehwolfde/src/app/embeds/mutuals/mutuals.component.ts
@@ -6,7 +6,7 @@ import { EmbedComponent } from '../embed/embed.component';
   selector: 'tehw0lf-mutuals',
   standalone: true,
   imports: [EmbedComponent],
-  template: `<tehw0lf-embed url="https://tehw0lf.github.io/mutuals/" />`,
+  template: `<tehw0lf-embed url="https://tehw0lf.github.io/mutuals/" title="Mutuals" />`,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class MutualsComponent {}

--- a/apps/tehwolfde/src/app/embeds/numveil/numveil.component.ts
+++ b/apps/tehwolfde/src/app/embeds/numveil/numveil.component.ts
@@ -6,7 +6,7 @@ import { EmbedComponent } from '../embed/embed.component';
   selector: 'tehw0lf-numveil',
   standalone: true,
   imports: [EmbedComponent],
-  template: `<tehw0lf-embed url="https://numveil.tehwolf.de" />`,
+  template: `<tehw0lf-embed url="https://numveil.tehwolf.de" title="Numveil" />`,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class NumveilComponent {}

--- a/apps/tehwolfde/src/index.html
+++ b/apps/tehwolfde/src/index.html
@@ -19,6 +19,7 @@
     />
   </head>
   <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <tehw0lf-root></tehw0lf-root>
   </body>
 </html>

--- a/apps/tehwolfde/src/styles.scss
+++ b/apps/tehwolfde/src/styles.scss
@@ -5,6 +5,10 @@
   font-family: global.$font;
 }
 
+#main-content {
+  outline: none;
+}
+
 .skip-link {
   position: absolute;
   top: -100%;

--- a/apps/tehwolfde/src/styles.scss
+++ b/apps/tehwolfde/src/styles.scss
@@ -5,6 +5,21 @@
   font-family: global.$font;
 }
 
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 0;
+  z-index: 9999;
+  padding: 8px 16px;
+  background: #000;
+  color: #fff;
+  text-decoration: none;
+
+  &:focus {
+    top: 0;
+  }
+}
+
 body {
   height: 100vh;
 }


### PR DESCRIPTION
## Summary

- Add `mat-label` and `aria-label` to color input fields (was placeholder-only before)
- Make iframe `title` a dynamic input on `EmbedComponent`; each embed wrapper passes its app name (Beep Simulator, BTrain, Flowdive, Mutuals, Numveil, Color)
- Add skip-to-content link in `index.html` with focus-visible styling (visually hidden until focused)
- Add `#main-content` focus target before `<router-outlet>` in mobile nav
- Focus `#main-content` on `NavigationEnd` so keyboard users land on content after navigation
- Suppress focus ring on programmatic focus target (`outline: none` on `#main-content`)

## Test plan

- [x] Lint passes (0 errors)
- [x] Unit tests pass (all green)
- [x] Build succeeds
- [x] 84/84 E2E tests pass (Chromium + Firefox)
- [ ] Manually verify skip link appears on Tab press from address bar
- [ ] Manually verify no focus ring flash on page load / route change