### PR TITLE
feat(i18n): add EN/DE language support

### DIFF
--- a/apps/tehwolfde/src/app/components/home/home.component.html
+++ b/apps/tehwolfde/src/app/components/home/home.component.html
@@ -1,10 +1,10 @@
 <div>
-  <h1 class="mat-headline-5">Welcome to tehwolf.de!</h1>
+  <h1 class="mat-headline-5">{{ 'home.welcome' | translate }}</h1>
   <div class="library-grid">
     @for (lib of libraries; track lib.route) {
       <mat-card [ngStyle]="cardStyle()">
         <mat-card-header>
-          <mat-card-title>{{ lib.title }}</mat-card-title>
+          <mat-card-title>{{ lib.titleKey }}</mat-card-title>
         </mat-card-header>
         <mat-card-content>
           <div class="preview-container">
@@ -15,11 +15,11 @@
               aria-hidden="true"
             ></iframe>
           </div>
-          <p class="description">{{ lib.description }}</p>
+          <p class="description">{{ lib.descriptionKey | translate }}</p>
         </mat-card-content>
         <mat-card-actions>
           <a mat-button [ngStyle]="buttonStyle()" [routerLink]="lib.route">
-            Try it
+            {{ 'home.tryIt' | translate }}
           </a>
         </mat-card-actions>
       </mat-card>

--- a/apps/tehwolfde/src/app/components/home/home.component.ts
+++ b/apps/tehwolfde/src/app/components/home/home.component.ts
@@ -5,11 +5,13 @@ import { MatCardModule } from '@angular/material/card';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { RouterLink } from '@angular/router';
 
+import { TranslatePipe } from '../../i18n/translate.pipe';
+import { TranslateService } from '../../i18n/translate.service';
 import { ThemeService } from '../../services/theme.service';
 
 interface LibraryCard {
-  title: string;
-  description: string;
+  titleKey: string;
+  descriptionKey: string;
   route: string;
   previewUrl: SafeResourceUrl;
 }
@@ -19,34 +21,32 @@ interface LibraryCard {
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss'],
   standalone: true,
-  imports: [RouterLink, MatButtonModule, MatCardModule, NgStyle],
+  imports: [RouterLink, MatButtonModule, MatCardModule, NgStyle, TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class HomeComponent {
   private themeService = inject(ThemeService);
   private sanitizer = inject(DomSanitizer);
+  translateService = inject(TranslateService);
 
   libraries: LibraryCard[] = [
     {
-      title: 'git-portfolio',
-      description:
-        'Customizable Git repository portfolio supporting GitHub and GitLab. Displays repos with stats, language colors, and links.',
+      titleKey: 'git-portfolio',
+      descriptionKey: 'home.gitPortfolioDescription',
       route: '/portfolio',
       previewUrl: this.sanitizer.bypassSecurityTrustResourceUrl('/portfolio')
     },
     {
-      title: 'wordlist-generator',
-      description:
-        'Cartesian product-based wordlist generator with drag-and-drop charset management and multiple export formats.',
+      titleKey: 'wordlist-generator',
+      descriptionKey: 'home.wordlistGeneratorDescription',
       route: '/wordlist-generator',
       previewUrl: this.sanitizer.bypassSecurityTrustResourceUrl(
         '/wordlist-generator'
       )
     },
     {
-      title: 'contact-form',
-      description:
-        'Flexible contact form built with ngx-formly. Supports dynamic fields, validation, and custom API callbacks.',
+      titleKey: 'contact-form',
+      descriptionKey: 'home.contactFormDescription',
       route: '/contact-form',
       previewUrl: this.sanitizer.bypassSecurityTrustResourceUrl('/contact-form')
     }

--- a/apps/tehwolfde/src/app/components/nav/desktop/desktop.component.html
+++ b/apps/tehwolfde/src/app/components/nav/desktop/desktop.component.html
@@ -10,7 +10,7 @@
       (click)="toggleSidenav()"
       [style]="burgerStyle()"
       mat-icon-button
-      aria-label="Open navigation menu"
+      [attr.aria-label]="'nav.openMenu' | translate"
     >
       <mat-icon>menu</mat-icon>
     </button>
@@ -24,13 +24,13 @@
         >
           <span class="mat-button-wrapper">
             <img alt="tehwolf.de" class="nav-logo" src="../../favicon.svg" />
-            <span>Home</span>
+            <span>{{ 'nav.home' | translate }}</span>
           </span>
         </a>
       </div>
       <div class="nav-item flex-gap-20">
         <a mat-button routerLink="/portfolio" routerLinkActive="link-active">
-          <span class="mat-button-wrapper"> <span>Portfolio</span> </span>
+          <span class="mat-button-wrapper"> <span>{{ 'nav.portfolio' | translate }}</span> </span>
         </a>
       </div>
       <div class="nav-item flex-gap-20">
@@ -40,21 +40,21 @@
           routerLinkActive="link-active"
         >
           <span class="mat-button-wrapper">
-            <span>Wordlist Generator</span>
+            <span>{{ 'nav.wordlistGenerator' | translate }}</span>
           </span>
         </a>
       </div>
       <div class="nav-item flex-gap-20">
         <a mat-button routerLink="/contact-form" routerLinkActive="link-active">
           <span class="mat-button-wrapper">
-            <span>Contact Form</span>
+            <span>{{ 'nav.contactForm' | translate }}</span>
           </span>
         </a>
       </div>
       <div class="nav-item flex-gap-20">
         <button mat-button [matMenuTriggerFor]="appsMenu">
           <span class="mat-button-wrapper">
-            <span>Apps</span>
+            <span>{{ 'nav.apps' | translate }}</span>
             <mat-icon>arrow_drop_down</mat-icon>
           </span>
         </button>
@@ -76,7 +76,7 @@
         (click)="switchToLight()"
         [style]="buttonStyle()"
         mat-icon-button
-        aria-label="Switch to light theme"
+        [attr.aria-label]="'nav.switchToLight' | translate"
       >
         <mat-icon>light_mode</mat-icon>
       </button>
@@ -88,11 +88,19 @@
         (click)="switchToDark()"
         [style]="buttonStyle()"
         mat-icon-button
-        aria-label="Switch to dark theme"
+        [attr.aria-label]="'nav.switchToDark' | translate"
       >
         <mat-icon>dark_mode</mat-icon>
       </button>
     }
+    <button
+      mat-icon-button
+      [style]="buttonStyle()"
+      (click)="translateService.toggle()"
+      [attr.aria-label]="'nav.switchLanguage' | translate"
+    >
+      <span>{{ translateService.locale() === 'en' ? 'DE' : 'EN' }}</span>
+    </button>
     <div [style]="buttonStyle()">
       <div class="nav-item">
         <a mat-button target="_blank" href="https://github.com/tehw0lf">
@@ -102,7 +110,7 @@
               class="nav-logo github"
               src="assets/icons/github.png"
             />
-            <span class="github">GitHub</span>
+            <span class="github">{{ 'nav.github' | translate }}</span>
           </span>
         </a>
       </div>

--- a/apps/tehwolfde/src/app/components/nav/desktop/desktop.component.ts
+++ b/apps/tehwolfde/src/app/components/nav/desktop/desktop.component.ts
@@ -9,6 +9,8 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { isActive, Router, RouterLink, RouterLinkActive } from '@angular/router';
 import { Subject, takeUntil } from 'rxjs';
 
+import { TranslatePipe } from '../../../i18n/translate.pipe';
+import { TranslateService } from '../../../i18n/translate.service';
 import { ThemeService } from '../../../services/theme.service';
 import { SidenavService } from '../sidenav.service';
 
@@ -24,12 +26,14 @@ import { SidenavService } from '../sidenav.service';
     MatIconModule,
     MatMenuModule,
     RouterLink,
-    RouterLinkActive
+    RouterLinkActive,
+    TranslatePipe
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DesktopComponent implements OnDestroy {
   themeService = inject(ThemeService);
+  translateService = inject(TranslateService);
   private router = inject(Router);
   private sidenavService = inject(SidenavService);
   private breakpointObserver = inject(BreakpointObserver);

--- a/apps/tehwolfde/src/app/components/nav/mobile/mobile.component.html
+++ b/apps/tehwolfde/src/app/components/nav/mobile/mobile.component.html
@@ -23,7 +23,7 @@
       >
         <span>
           <img alt="tehwolf.de" class="nav-logo" src="../../favicon.svg" />
-          <span>Home </span>
+          <span>{{ 'nav.home' | translate }}</span>
         </span> </a
       ><a
         (click)="closeSidenav()"
@@ -31,7 +31,7 @@
         routerLinkActive="link-active"
         mat-list-item
       >
-        <span>Portfolio</span> </a
+        <span>{{ 'nav.portfolio' | translate }}</span> </a
       ><a
         (click)="closeSidenav()"
         routerLink="/wordlist-generator"
@@ -39,7 +39,7 @@
         mat-list-item
       >
         <span>
-          <span>Wordlist Generator</span>
+          <span>{{ 'nav.wordlistGenerator' | translate }}</span>
         </span>
       </a>
       <a
@@ -49,11 +49,11 @@
         mat-list-item
       >
         <span>
-          <span>Contact Form (Demo)</span>
+          <span>{{ 'nav.contactForm' | translate }}</span>
         </span>
       </a>
       <mat-divider></mat-divider>
-      <h3 matSubheader class="apps-subheader">Apps</h3>
+      <h3 matSubheader class="apps-subheader">{{ 'nav.apps' | translate }}</h3>
       <a (click)="closeSidenav()" routerLink="/flowdive" routerLinkActive="link-active" mat-list-item>
         <span>Flowdive</span>
       </a>
@@ -85,7 +85,7 @@
             class="nav-logo"
             src="assets/icons/github.png"
           />
-          <span>GitHub</span>
+          <span>{{ 'nav.github' | translate }}</span>
         </span>
       </a>
       <div>
@@ -94,7 +94,7 @@
           type="button"
           (click)="toggleSidenav()"
           mat-icon-button
-          aria-label="Close navigation menu"
+          [attr.aria-label]="'nav.closeMenu' | translate"
         >
           <mat-icon>menu</mat-icon>
         </button>
@@ -105,7 +105,7 @@
             type="button"
             (click)="switchToLight()"
             mat-icon-button
-            aria-label="Switch to light theme"
+            [attr.aria-label]="'nav.switchToLight' | translate"
           >
             <mat-icon>light_mode</mat-icon>
           </button>
@@ -117,11 +117,18 @@
             type="button"
             (click)="switchToDark()"
             mat-icon-button
-            aria-label="Switch to dark theme"
+            [attr.aria-label]="'nav.switchToDark' | translate"
           >
             <mat-icon>dark_mode</mat-icon>
           </button>
         }
+        <button
+          mat-icon-button
+          (click)="translateService.toggle()"
+          [attr.aria-label]="'nav.switchLanguage' | translate"
+        >
+          <span>{{ translateService.locale() === 'en' ? 'DE' : 'EN' }}</span>
+        </button>
       </div>
     </mat-nav-list>
   </mat-sidenav>

--- a/apps/tehwolfde/src/app/components/nav/mobile/mobile.component.ts
+++ b/apps/tehwolfde/src/app/components/nav/mobile/mobile.component.ts
@@ -19,6 +19,8 @@ import { MatSidenav, MatSidenavModule } from '@angular/material/sidenav';
 import { isActive, Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { Subject } from 'rxjs';
 
+import { TranslatePipe } from '../../../i18n/translate.pipe';
+import { TranslateService } from '../../../i18n/translate.service';
 import { ThemeService } from '../../../services/theme.service';
 import { SidenavService } from '../sidenav.service';
 
@@ -37,12 +39,14 @@ import { SidenavService } from '../sidenav.service';
     RouterLinkActive,
     MatButtonModule,
     MatIconModule,
-    RouterOutlet
+    RouterOutlet,
+    TranslatePipe
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class MobileComponent implements AfterViewInit, OnDestroy {
   themeService = inject(ThemeService);
+  translateService = inject(TranslateService);
   private router = inject(Router);
   private sidenavService = inject(SidenavService);
 

--- a/apps/tehwolfde/src/app/embeds/color/color.component.html
+++ b/apps/tehwolfde/src/app/embeds/color/color.component.html
@@ -1,6 +1,6 @@
 <div class="color-controls">
   <mat-form-field appearance="outline">
-    <mat-label>Color value</mat-label>
+    <mat-label>{{ 'color.label' | translate }}</mat-label>
     <input
       matInput
       [ngModel]="inputValue()"
@@ -14,7 +14,7 @@
     [value]="hexColor()"
     (input)="inputValue.set($any($event.target).value); apply()"
     class="color-picker"
-    aria-label="Color picker"
+    [attr.aria-label]="'color.pickerLabel' | translate"
   />
 </div>
 <tehw0lf-embed [url]="iframeUrl()" title="Color" />

--- a/apps/tehwolfde/src/app/embeds/color/color.component.ts
+++ b/apps/tehwolfde/src/app/embeds/color/color.component.ts
@@ -4,6 +4,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatInputModule } from '@angular/material/input';
 import { ActivatedRoute, Router } from '@angular/router';
 
+import { TranslatePipe } from '../../i18n/translate.pipe';
 import { EmbedComponent } from '../embed/embed.component';
 
 function resolveToHex(colorValue: string): string {
@@ -23,7 +24,7 @@ function resolveToHex(colorValue: string): string {
   templateUrl: './color.component.html',
   styleUrl: './color.component.scss',
   standalone: true,
-  imports: [EmbedComponent, FormsModule, MatInputModule, MatButtonModule],
+  imports: [EmbedComponent, FormsModule, MatInputModule, MatButtonModule, TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ColorComponent {

--- a/apps/tehwolfde/src/app/i18n/translate.pipe.ts
+++ b/apps/tehwolfde/src/app/i18n/translate.pipe.ts
@@ -1,0 +1,12 @@
+import { inject, Pipe, PipeTransform } from '@angular/core';
+
+import { TranslateService } from './translate.service';
+
+@Pipe({ name: 'translate', standalone: true, pure: false })
+export class TranslatePipe implements PipeTransform {
+  private translateService = inject(TranslateService);
+
+  transform(key: string): string {
+    return this.translateService.translate(key);
+  }
+}

--- a/apps/tehwolfde/src/app/i18n/translate.service.ts
+++ b/apps/tehwolfde/src/app/i18n/translate.service.ts
@@ -1,0 +1,29 @@
+import { effect, inject, Injectable, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+export type Locale = 'en' | 'de';
+
+@Injectable({ providedIn: 'root' })
+export class TranslateService {
+  private http = inject(HttpClient);
+
+  locale = signal<Locale>('en');
+  private translations = signal<Record<string, string>>({});
+
+  constructor() {
+    effect(() => {
+      const locale = this.locale();
+      this.http
+        .get<Record<string, string>>(`/assets/i18n/${locale}.json`)
+        .subscribe((t) => this.translations.set(t));
+    });
+  }
+
+  translate(key: string): string {
+    return this.translations()[key] ?? key;
+  }
+
+  toggle(): void {
+    this.locale.update((l) => (l === 'en' ? 'de' : 'en'));
+  }
+}

--- a/apps/tehwolfde/src/app/showcases/contact-form/contact-form.component.html
+++ b/apps/tehwolfde/src/app/showcases/contact-form/contact-form.component.html
@@ -1,9 +1,12 @@
 <h2 mat-headline>
-  This is a non-functional demo that performs no actual HTTP calls
+  {{ 'contactForm.demoNotice' | translate }}
 </h2>
 
 <contact-form
   [buttonStyle]="buttonStyle()"
   [formStyle]="formStyle()"
   [apiCallback]="apiCallback"
+  [sendText]="translateService.translate('contactForm.send')"
+  [sendSuccessfulText]="translateService.translate('contactForm.sendSuccess')"
+  [sendErrorText]="translateService.translate('contactForm.sendError')"
 ></contact-form>

--- a/apps/tehwolfde/src/app/showcases/contact-form/contact-form.component.ts
+++ b/apps/tehwolfde/src/app/showcases/contact-form/contact-form.component.ts
@@ -2,17 +2,20 @@ import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/c
 import { ContactFormComponent as ContactFormComponent_1 } from '@tehw0lf/contact-form';
 import { of } from 'rxjs';
 
+import { TranslatePipe } from '../../i18n/translate.pipe';
+import { TranslateService } from '../../i18n/translate.service';
 import { ThemeService } from '../../services/theme.service';
 
 @Component({
   selector: 'tehw0lf-contact-form',
   templateUrl: './contact-form.component.html',
   styleUrls: ['./contact-form.component.scss'],
-  imports: [ContactFormComponent_1],
+  imports: [ContactFormComponent_1, TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ContactFormComponent {
   private themeService = inject(ThemeService);
+  translateService = inject(TranslateService);
 
   buttonStyle = computed(() => ({
     'background-color':

--- a/apps/tehwolfde/src/app/showcases/git-portfolio/git-portfolio.component.html
+++ b/apps/tehwolfde/src/app/showcases/git-portfolio/git-portfolio.component.html
@@ -2,4 +2,5 @@
   [buttonStyle]="buttonStyle()"
   [cardStyle]="cardStyle()"
   [gitProviderConfig]="gitProviderConfig"
+  [labels]="gitPortfolioLabels"
 ></git-portfolio>

--- a/apps/tehwolfde/src/app/showcases/git-portfolio/git-portfolio.component.ts
+++ b/apps/tehwolfde/src/app/showcases/git-portfolio/git-portfolio.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { GitPortfolioComponent as GitPortfolioComponent_1, GitProviderConfig } from '@tehw0lf/git-portfolio';
 
+import { TranslateService } from '../../i18n/translate.service';
 import { ThemeService } from '../../services/theme.service';
 
 @Component({
@@ -11,6 +12,7 @@ import { ThemeService } from '../../services/theme.service';
 })
 export class GitPortfolioComponent {
   private themeService = inject(ThemeService);
+  translateService = inject(TranslateService);
 
   buttonStyle = computed(() => ({
     'background-color':
@@ -32,4 +34,17 @@ export class GitPortfolioComponent {
   gitProviderConfig: GitProviderConfig = {
     github: 'tehw0lf'
   };
+
+  get gitPortfolioLabels() {
+    const t = this.translateService.translate.bind(this.translateService);
+    return {
+      ownRepos: t('gitPortfolio.ownRepos'),
+      forkedRepos: t('gitPortfolio.forkedRepos'),
+      noOwnRepos: t('gitPortfolio.noOwnRepos'),
+      noForkedRepos: t('gitPortfolio.noForkedRepos'),
+      copyRepoUrl: t('gitPortfolio.copyRepoUrl'),
+      created: t('gitPortfolio.created'),
+      updated: t('gitPortfolio.updated')
+    };
+  }
 }

--- a/apps/tehwolfde/src/app/showcases/wordlist-generator/wordlist-generator.component.html
+++ b/apps/tehwolfde/src/app/showcases/wordlist-generator/wordlist-generator.component.html
@@ -1,1 +1,1 @@
-<wordlist-generator [buttonStyle]="buttonStyle()"></wordlist-generator>
+<wordlist-generator [buttonStyle]="buttonStyle()" [labels]="wordlistLabels"></wordlist-generator>

--- a/apps/tehwolfde/src/app/showcases/wordlist-generator/wordlist-generator.component.ts
+++ b/apps/tehwolfde/src/app/showcases/wordlist-generator/wordlist-generator.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { WordlistGeneratorComponent as WordlistGeneratorComponent_1 } from '@tehw0lf/wordlist-generator';
 
+import { TranslateService } from '../../i18n/translate.service';
 import { ThemeService } from '../../services/theme.service';
 
 @Component({
@@ -11,6 +12,7 @@ import { ThemeService } from '../../services/theme.service';
 })
 export class WordlistGeneratorComponent {
   themeService = inject(ThemeService);
+  translateService = inject(TranslateService);
 
   buttonStyle = computed(() => ({
     'background-color':
@@ -19,4 +21,20 @@ export class WordlistGeneratorComponent {
         : 'rgba(255, 255, 255, 0.75)',
     color: '#cc7832'
   }));
+
+  get wordlistLabels() {
+    const t = this.translateService.translate.bind(this.translateService);
+    return {
+      generating: t('wordlistGenerator.generating'),
+      generate: t('wordlistGenerator.generate'),
+      chooseFormat: t('wordlistGenerator.chooseFormat'),
+      downloadAs: t('wordlistGenerator.downloadAs'),
+      processingLarge: t('wordlistGenerator.processingLarge'),
+      prefix: t('wordlistGenerator.prefix'),
+      charsetPosition: t('wordlistGenerator.charsetPosition'),
+      suffix: t('wordlistGenerator.suffix'),
+      generatedWordlist: t('wordlistGenerator.generatedWordlist'),
+      tooLarge: t('wordlistGenerator.tooLarge')
+    };
+  }
 }

--- a/apps/tehwolfde/src/assets/i18n/de.json
+++ b/apps/tehwolfde/src/assets/i18n/de.json
@@ -1,0 +1,48 @@
+{
+  "nav.home": "Startseite",
+  "nav.portfolio": "Portfolio",
+  "nav.wordlistGenerator": "Wortlisten-Generator",
+  "nav.contactForm": "Kontaktformular",
+  "nav.apps": "Apps",
+  "nav.github": "GitHub",
+  "nav.openMenu": "Navigationsmenü öffnen",
+  "nav.closeMenu": "Navigationsmenü schließen",
+  "nav.switchToLight": "Helles Design aktivieren",
+  "nav.switchToDark": "Dunkles Design aktivieren",
+  "nav.switchLanguage": "Sprache wechseln",
+
+  "home.welcome": "Willkommen auf tehwolf.de!",
+  "home.tryIt": "Ausprobieren",
+  "home.gitPortfolioDescription": "Anpassbares Git-Repository-Portfolio mit Unterstützung für GitHub und GitLab. Zeigt Repos mit Statistiken, Sprachfarben und Links.",
+  "home.wordlistGeneratorDescription": "Kartesisches-Produkt-basierter Wortlisten-Generator mit Drag-and-Drop-Zeichensatz-Verwaltung und mehreren Exportformaten.",
+  "home.contactFormDescription": "Flexibles Kontaktformular auf Basis von ngx-formly. Unterstützt dynamische Felder, Validierung und benutzerdefinierte API-Callbacks.",
+
+  "contactForm.demoNotice": "Dies ist eine nicht-funktionale Demo, die keine HTTP-Anfragen sendet",
+  "contactForm.send": "Senden",
+  "contactForm.sendSuccess": "E-Mail erfolgreich gesendet",
+  "contactForm.sendError": "Sendefehler",
+
+  "color.label": "Farbwert",
+  "color.pickerLabel": "Farbwähler",
+
+  "embed.openInNewTab": "In neuem Tab öffnen",
+
+  "gitPortfolio.ownRepos": "Eigene Repos",
+  "gitPortfolio.forkedRepos": "Geforkte Repos",
+  "gitPortfolio.noOwnRepos": "Dieser Nutzer hat noch keine Repositories erstellt",
+  "gitPortfolio.noForkedRepos": "Dieser Nutzer hat noch keine Repositories geforkt",
+  "gitPortfolio.copyRepoUrl": "Repo-URL kopieren",
+  "gitPortfolio.created": "Erstellt: ",
+  "gitPortfolio.updated": "Aktualisiert: ",
+
+  "wordlistGenerator.generating": "Generiere...",
+  "wordlistGenerator.generate": "Wortliste generieren",
+  "wordlistGenerator.chooseFormat": "Format wählen",
+  "wordlistGenerator.downloadAs": "Herunterladen als",
+  "wordlistGenerator.processingLarge": "Großer Datensatz wird mit Web Worker verarbeitet...",
+  "wordlistGenerator.prefix": "Präfix (optional)",
+  "wordlistGenerator.charsetPosition": "Zeichensatz für Stringposition ",
+  "wordlistGenerator.suffix": "Suffix (optional)",
+  "wordlistGenerator.generatedWordlist": "Generierte Wortliste:",
+  "wordlistGenerator.tooLarge": "Die generierte Wortliste ist zu groß für die Anzeige. Du kannst sie trotzdem herunterladen."
+}

--- a/apps/tehwolfde/src/assets/i18n/en.json
+++ b/apps/tehwolfde/src/assets/i18n/en.json
@@ -1,0 +1,48 @@
+{
+  "nav.home": "Home",
+  "nav.portfolio": "Portfolio",
+  "nav.wordlistGenerator": "Wordlist Generator",
+  "nav.contactForm": "Contact Form",
+  "nav.apps": "Apps",
+  "nav.github": "GitHub",
+  "nav.openMenu": "Open navigation menu",
+  "nav.closeMenu": "Close navigation menu",
+  "nav.switchToLight": "Switch to light theme",
+  "nav.switchToDark": "Switch to dark theme",
+  "nav.switchLanguage": "Switch language",
+
+  "home.welcome": "Welcome to tehwolf.de!",
+  "home.tryIt": "Try it",
+  "home.gitPortfolioDescription": "Customizable Git repository portfolio supporting GitHub and GitLab. Displays repos with stats, language colors, and links.",
+  "home.wordlistGeneratorDescription": "Cartesian product-based wordlist generator with drag-and-drop charset management and multiple export formats.",
+  "home.contactFormDescription": "Flexible contact form built with ngx-formly. Supports dynamic fields, validation, and custom API callbacks.",
+
+  "contactForm.demoNotice": "This is a non-functional demo that performs no actual HTTP calls",
+  "contactForm.send": "Send",
+  "contactForm.sendSuccess": "E-Mail successfully sent",
+  "contactForm.sendError": "Send error",
+
+  "color.label": "Color value",
+  "color.pickerLabel": "Color picker",
+
+  "embed.openInNewTab": "Open in new tab",
+
+  "gitPortfolio.ownRepos": "Own Repos",
+  "gitPortfolio.forkedRepos": "Forked Repos",
+  "gitPortfolio.noOwnRepos": "This user has not created any repositories yet",
+  "gitPortfolio.noForkedRepos": "This user has not forked any repositories yet",
+  "gitPortfolio.copyRepoUrl": "Copy repo URL",
+  "gitPortfolio.created": "Created: ",
+  "gitPortfolio.updated": "Updated: ",
+
+  "wordlistGenerator.generating": "Generating...",
+  "wordlistGenerator.generate": "Generate wordlist",
+  "wordlistGenerator.chooseFormat": "Choose format",
+  "wordlistGenerator.downloadAs": "Download as",
+  "wordlistGenerator.processingLarge": "Processing large dataset using Web Worker...",
+  "wordlistGenerator.prefix": "prefix (optional)",
+  "wordlistGenerator.charsetPosition": "character set for string position ",
+  "wordlistGenerator.suffix": "suffix (optional)",
+  "wordlistGenerator.generatedWordlist": "Generated wordlist:",
+  "wordlistGenerator.tooLarge": "The generated wordlist is too large to be displayed. You can still download it."
+}

--- a/libs/git-portfolio/src/lib/git-portfolio.component.html
+++ b/libs/git-portfolio/src/lib/git-portfolio.component.html
@@ -6,7 +6,7 @@
           <h1 [ngStyle]="textStyle()" class="mat-headline">{{ gitProvider.value }}</h1>
           @if (showOwn()) {
             <div>
-              <h2 [ngStyle]="textStyle()" class="mat-headline">Own Repos</h2>
+              <h2 [ngStyle]="textStyle()" class="mat-headline">{{ labels().ownRepos }}</h2>
               <div
                 class="flex-align-start"
                 [ngClass]="{
@@ -39,6 +39,7 @@
                     [starColor]="starColor()"
                     [gitRepo]="gitRepo"
                     [isCopied]="isCopiedToClipboard(gitRepo)"
+                    [labels]="repoCardLabels()"
                     (copiedToClipboard)="copyToClipboard(gitRepo)"
                     class="repository-card flex-align-stretch"
                     [ngClass]="{
@@ -57,16 +58,14 @@
                     'own'
                   )
                 ) {
-                  <div [ngStyle]="textStyle()">
-                    This user has not created any repositories yet
-                  </div>
+                  <div [ngStyle]="textStyle()">{{ labels().noOwnRepos }}</div>
                 }
               </div>
             </div>
           }
           @if (showForked()) {
             <div>
-              <h2 [ngStyle]="textStyle()" class="mat-headline">Forked Repos</h2>
+              <h2 [ngStyle]="textStyle()" class="mat-headline">{{ labels().forkedRepos }}</h2>
               <div
                 class="flex-align-start"
                 [ngClass]="{
@@ -99,6 +98,7 @@
                     [starColor]="starColor()"
                     [gitRepo]="gitRepo"
                     [isCopied]="isCopiedToClipboard(gitRepo)"
+                    [labels]="repoCardLabels()"
                     (copiedToClipboard)="copyToClipboard(gitRepo)"
                     class="repository-card flex-align-stretch"
                     [ngClass]="{
@@ -116,9 +116,7 @@
                     'forked'
                   )
                 ) {
-                  <div [ngStyle]="textStyle()">
-                    This user has not forked any repositories yet
-                  </div>
+                  <div [ngStyle]="textStyle()">{{ labels().noForkedRepos }}</div>
                 }
               </div>
             </div>

--- a/libs/git-portfolio/src/lib/git-portfolio.component.ts
+++ b/libs/git-portfolio/src/lib/git-portfolio.component.ts
@@ -4,7 +4,7 @@ import {
   LayoutModule
 } from '@angular/cdk/layout';
 import { CommonModule, KeyValuePipe, NgStyle } from '@angular/common';
-import { ChangeDetectionStrategy, Component, input, inject, signal, effect, OnDestroy } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, inject, signal, effect, computed, OnDestroy } from '@angular/core';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { takeUntil, tap } from 'rxjs/operators';
@@ -61,6 +61,22 @@ export class GitPortfolioComponent implements OnDestroy {
   showForked = input(true);
 
   showOwn = input(true);
+
+  labels = input({
+    ownRepos: 'Own Repos',
+    forkedRepos: 'Forked Repos',
+    noOwnRepos: 'This user has not created any repositories yet',
+    noForkedRepos: 'This user has not forked any repositories yet',
+    copyRepoUrl: 'Copy repo URL',
+    created: 'Created: ',
+    updated: 'Updated: '
+  });
+
+  repoCardLabels = computed(() => ({
+    copyRepoUrl: this.labels().copyRepoUrl,
+    created: this.labels().created,
+    updated: this.labels().updated
+  }));
 
   loading = toSignal(this.gitProviderService.loading, { initialValue: true });
   gitProviders = GitProviders;

--- a/libs/git-portfolio/src/lib/repo-card/repo-card.component.html
+++ b/libs/git-portfolio/src/lib/repo-card/repo-card.component.html
@@ -67,13 +67,8 @@
   </mat-card-content>
   <mat-card-footer class="flex-row">
     <span class="mat-footer-cell flex-fxflex flex-gap-12">
-      <span class="footer-span" [ngStyle]="textStyle()"
-        >Created: {{ gitRepo().created_at | date }}</span
-      >
-      <span class="footer-span" [ngStyle]="textStyle()"
-        >Updated:
-        {{ gitRepo().pushed_at || gitRepo().last_activity_at | date }}</span
-      >
+      <span class="footer-span" [ngStyle]="textStyle()">{{ labels().created }}{{ gitRepo().created_at | date }}</span>
+      <span class="footer-span" [ngStyle]="textStyle()">{{ labels().updated }}{{ gitRepo().pushed_at || gitRepo().last_activity_at | date }}</span>
     </span>
     <span class="mat-footer-cell">
       <button
@@ -100,7 +95,7 @@
             width="24px"
             class="flex-gap-5"
           ></div>
-          <span>Copy repo URL</span>
+          <span>{{ labels().copyRepoUrl }}</span>
         </span>
       </button>
     </span>

--- a/libs/git-portfolio/src/lib/repo-card/repo-card.component.ts
+++ b/libs/git-portfolio/src/lib/repo-card/repo-card.component.ts
@@ -42,6 +42,12 @@ export class RepoCardComponent {
 
   isCopied = input(false);
 
+  labels = input({
+    copyRepoUrl: 'Copy repo URL',
+    created: 'Created: ',
+    updated: 'Updated: '
+  });
+
   copiedToClipboard = output<boolean>();
 
   githubLanguageColors = githubLanguageColors as Dictionary;

--- a/libs/wordlist-generator/src/lib/wordlist-generator.component.html
+++ b/libs/wordlist-generator/src/lib/wordlist-generator.component.html
@@ -9,9 +9,9 @@
         [disabled]="isGenerating()"
       >
         @if (isGenerating()) {
-          Generating...
+          {{ labels().generating }}
         } @else {
-          Generate wordlist
+          {{ labels().generate }}
         }
       </button>
       @if (hasWordlist() && !isGenerating()) {
@@ -21,7 +21,7 @@
           mat-raised-button
           [matMenuTriggerFor]="menu"
         >
-          Choose format
+          {{ labels().chooseFormat }}
         </button>
       }
       <mat-menu #menu="matMenu">
@@ -42,25 +42,25 @@
           mat-raised-button
           (click)="downloadWordlist()"
         >
-          Download as
+          {{ labels().downloadAs }}
           @if (this.fileType()) {
             {{ this.fileType() }}
           }
         </button>
       }
     </div>
-    
+
     @if (isGenerating() && isLargeDataset()) {
       <div class="progress-container">
         <mat-progress-bar mode="indeterminate" role="progressbar" aria-label="Generating wordlist"></mat-progress-bar>
-        <p [ngStyle]="textStyle()">Processing large dataset using Web Worker...</p>
+        <p [ngStyle]="textStyle()">{{ labels().processingLarge }}</p>
       </div>
     }
-    
+
     @if (charsetForm) {
       <form [formGroup]="charsetForm">
         <mat-form-field class="fixed-width bottom-10" appearance="outline">
-          <mat-label [ngStyle]="textStyle()">prefix (optional)</mat-label>
+          <mat-label [ngStyle]="textStyle()">{{ labels().prefix }}</mat-label>
           <input
             [ngStyle]="textStyle()"
             matInput
@@ -83,7 +83,7 @@
                 >
                 <mat-form-field class="charset bottom-10" appearance="outline">
                   <mat-label [ngStyle]="textStyle()">
-                    character set for string position {{ i }}
+                    {{ labels().charsetPosition }}{{ i }}
                   </mat-label>
                   <input
                     [ngStyle]="textStyle()"
@@ -124,7 +124,7 @@
           </div>
         </div>
         <mat-form-field class="fixed-width" appearance="outline">
-          <mat-label [ngStyle]="textStyle()">suffix (optional)</mat-label>
+          <mat-label [ngStyle]="textStyle()">{{ labels().suffix }}</mat-label>
           <input
             [ngStyle]="textStyle()"
             matInput
@@ -140,14 +140,12 @@
   @if (hasWordlist()) {
     <div class="wordlist-container flex-column flex-fxflex">
       @if (displayWordlist()) {
-        <h3 class="wordlist-header">Generated wordlist:</h3>
+        <h3 class="wordlist-header">{{ labels().generatedWordlist }}</h3>
         <code class="wordlist">
           {{ wordlist() }}
         </code>
       } @else {
-        The generated wordlist is too large to be displayed. You can still
-        download it.
-        <!-- Wordlist is already loaded in the signal for large datasets -->
+        {{ labels().tooLarge }}
       }
     </div>
   }

--- a/libs/wordlist-generator/src/lib/wordlist-generator.component.ts
+++ b/libs/wordlist-generator/src/lib/wordlist-generator.component.ts
@@ -67,6 +67,19 @@ export class WordlistGeneratorComponent implements OnDestroy {
   dragStyle = input({ color: '#cc7832' });
   textStyle = input({ color: '#cc7832' });
 
+  labels = input({
+    generating: 'Generating...',
+    generate: 'Generate wordlist',
+    chooseFormat: 'Choose format',
+    downloadAs: 'Download as',
+    processingLarge: 'Processing large dataset using Web Worker...',
+    prefix: 'prefix (optional)',
+    charsetPosition: 'character set for string position ',
+    suffix: 'suffix (optional)',
+    generatedWordlist: 'Generated wordlist:',
+    tooLarge: 'The generated wordlist is too large to be displayed. You can still download it.'
+  });
+
   charsetForm: UntypedFormGroup | undefined;
   wordlist = signal<string>('');
 


### PR DESCRIPTION
## Summary

- Add `TranslateService` (signal-based, loads locale JSON at runtime via `HttpClient`) and `TranslatePipe` (`pure: false` for reactivity)
- Add `assets/i18n/en.json` and `de.json` covering all app and library strings
- Add DE/EN language toggle button to desktop and mobile nav
- Wire `translate` pipe into all app templates: nav, home, contact-form banner, color input label
- Add `labels` input to `git-portfolio` library (ownRepos, forkedRepos, empty states, copyRepoUrl, created, updated) — passed through to `repo-card`
- Add `labels` input to `wordlist-generator` library (all button/label/status strings)
- Showcase components compute translated label objects and pass them into library inputs
- `contact-form` already had `sendText`/`sendSuccessfulText`/`sendErrorText` inputs — wired up

## Test plan

- [x] Lint passes (0 errors)
- [x] Unit tests pass
- [x] Build succeeds
- [x] 84/84 E2E tests pass (Chromium + Firefox)
- [ ] Manually verify DE/EN toggle switches all visible strings
- [ ] Manually verify language persists across route navigation