### PR TITLE
fix(mobile): improve responsive layout for repo-card and wordlist-generator

### DIFF
--- a/libs/git-portfolio/package.json
+++ b/libs/git-portfolio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tehw0lf/git-portfolio",
-  "version": "0.21.9",
+  "version": "0.21.10",
   "license": "MIT",
   "homepage": "https://github.com/tehw0lf/tehwol.fi.git",
   "repository": {

--- a/libs/git-portfolio/src/lib/git-portfolio.component.scss
+++ b/libs/git-portfolio/src/lib/git-portfolio.component.scss
@@ -3,6 +3,13 @@
 .repository-card {
   max-width: 450px;
   margin: 0 32px 32px 0;
+
+  @media screen and (max-width: 519px) {
+    max-width: 100%;
+    width: 100%;
+    margin: 0 0 16px 0;
+    box-sizing: border-box;
+  }
 }
 
 .mat-headline {

--- a/libs/git-portfolio/src/lib/repo-card/repo-card.component.scss
+++ b/libs/git-portfolio/src/lib/repo-card/repo-card.component.scss
@@ -20,8 +20,9 @@
   text-align: center;
   text-decoration: none;
 
-  @media screen and (max-width: 400px) {
-    font-size: 20px;
+  @media screen and (max-width: 519px) {
+    font-size: 16px;
+    padding: 0 8px;
   }
 }
 
@@ -29,21 +30,11 @@
   display: flex;
   flex-direction: column;
   width: 450px;
+  max-width: 100%;
+  box-sizing: border-box;
 
   @media screen and (max-width: 519px) {
-    width: 415px;
-  }
-
-  @media screen and (max-width: 430px) {
-    width: 380px;
-  }
-
-  @media screen and (max-width: 400px) {
-    width: 350px;
-  }
-
-  @media screen and (max-width: 390px) {
-    width: 310px;
+    width: 100%;
   }
 }
 

--- a/libs/wordlist-generator/package.json
+++ b/libs/wordlist-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tehw0lf/wordlist-generator",
-  "version": "0.21.8",
+  "version": "0.21.9",
   "license": "MIT",
   "homepage": "https://github.com/tehw0lf/tehwol.fi.git",
   "repository": {

--- a/libs/wordlist-generator/src/lib/wordlist-generator.component.scss
+++ b/libs/wordlist-generator/src/lib/wordlist-generator.component.scss
@@ -37,22 +37,25 @@
     }
 
     .choose-format {
-      margin: 0 34px 10px 34px;
-      width: 150px;
+      margin: 0 10px 10px 0;
+      min-width: 150px;
       line-height: 36px;
       letter-spacing: normal;
     }
 
     .generate-wordlist {
-      margin: 0 0 10px 0;
-      width: 150px;
+      margin: 0 10px 10px 0;
+      min-width: 150px;
       line-height: 36px;
       letter-spacing: normal;
+      white-space: normal;
+      height: auto;
+      padding: 6px 16px;
     }
 
     .download-wordlist {
       margin: 0 0 10px 0;
-      width: 150px;
+      min-width: 150px;
       line-height: 36px;
       letter-spacing: normal;
     }


### PR DESCRIPTION
## Summary

- Replace fixed pixel widths in `repo-card` with fluid `width: 100%` / `max-width: 100%` on screens ≤519px — cards no longer overflow the viewport on mobile
- Simplify breakpoint logic from 4 hardcoded pixel steps down to one clean boundary
- Fix `generate-wordlist` button: `min-width` + `white-space: normal` + `height: auto` so translated labels (e.g. German "Wortliste generieren") wrap instead of overflowing
- Bump `@tehw0lf/git-portfolio` → 0.21.10, `@tehw0lf/wordlist-generator` → 0.21.9

## Test plan

- [ ] Open portfolio on a mobile viewport (≤430px) and verify repo cards fill the width without horizontal scroll
- [ ] Switch wordlist-generator to German locale and confirm the generate button displays fully without clipping
- [ ] Confirm desktop layout (>519px) is unchanged
- [ ] `npm run lint && npm run test && npm run build` all pass