### PR TITLE
Reenable e2e tests in CI

### DIFF
--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -19,19 +19,19 @@ jobs:
       security-events: write
       pull-requests: write
     with:
-      tool: 'npm'
-      format: 'run format'
-      # lint: "run affected:lint" # temporarily disabled due to false positives
-      test: 'run test:ci'
-      # e2e: 'run e2e' # temporarily disabled - playwright browser download times out on CI runner
-      build_branch: 'run affected:build'
-      build_main: 'run build --skip-nx-cache'
-      docker_pre: '[ -d ./dist/apps ] && mv -fv avatar* dist/apps/tehwolfde/browser/'
+      tool: "npm"
+      format: "run format"
+      lint: "run affected:lint"
+      test: "run test:ci"
+      e2e: "run e2e"
+      build_branch: "run affected:build"
+      build_main: "run build --skip-nx-cache"
+      docker_pre: "[ -d ./dist/apps ] && mv -fv avatar* dist/apps/tehwolfde/browser/"
       docker_meta: '[{"name":"tehwolf.de","file":"Dockerfile"}]'
-      libraries: 'contact-form,git-portfolio,wordlist-generator'
-      library_path: 'dist/libs'
-      artifact_path: 'dist'
-      platforms: 'linux/arm64'
+      libraries: "contact-form,git-portfolio,wordlist-generator"
+      library_path: "dist/libs"
+      artifact_path: "dist"
+      platforms: "linux/arm64"
       cyclonedx_ignore_npm_errors: true
       npm_audit_omit_dev: true
     secrets:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.21.13",
+  "version": "0.21.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.21.13",
+      "version": "0.21.14",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "21.2.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "@nx/jest": "22.7.5",
         "@nx/playwright": "22.7.5",
         "@nx/workspace": "22.7.5",
-        "@playwright/test": "1.58.0",
+        "@playwright/test": "1.60.0",
         "@schematics/angular": "21.2.7",
         "@swc/core": "1.15.18",
         "@swc/jest": "0.2.39",
@@ -10982,13 +10982,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
-      "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.0"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -26967,13 +26967,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
-      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.0"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -26986,9 +26986,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
-      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.21.13",
+  "version": "0.21.14",
   "license": "MIT",
   "scripts": {
     "ng": "nx",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@types/primer__octicons": "19.21.0",
     "@typescript-eslint/utils": "8.56.1",
     "autoprefixer": "10.4.23",
-    "@playwright/test": "1.58.0",
+    "@playwright/test": "1.60.0",
     "dotenv": "17.2.3",
     "eslint": "9.39.3",
     "eslint-config-prettier": "10.1.8",


### PR DESCRIPTION
* Re-enable lint and e2e tests in the CI workflow.
* Ensure all necessary scripts are included for the build process.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.21.14
  * Updated dev test tooling to Playwright 1.60.0
  * Build pipeline configuration standardized and now enables automated lint and end-to-end checks during CI
<!-- end of auto-generated comment: release notes by coderabbit.ai -->