### PR TITLE
feat(routes): add 'farbduell' route and component

### DIFF
--- a/apps/tehwolfde/src/app/app.routes.ts
+++ b/apps/tehwolfde/src/app/app.routes.ts
@@ -66,6 +66,13 @@ export const routes: Routes = [
       import('./embeds/btrain/btrain.component').then((m) => m.BtrainComponent)
   },
   {
+    path: 'farbduell',
+    loadComponent: () =>
+      import('./embeds/farbduell/farbduell.component').then(
+        (m) => m.FarbduellComponent
+      )
+  },
+  {
     path: 'color/:color',
     loadComponent: () =>
       import('./embeds/color/color.component').then((m) => m.ColorComponent)

--- a/apps/tehwolfde/src/app/components/nav/desktop/desktop.component.html
+++ b/apps/tehwolfde/src/app/components/nav/desktop/desktop.component.html
@@ -65,6 +65,7 @@
           <a mat-menu-item routerLink="/btrain" routerLinkActive="link-active">BTrain</a>
           <a mat-menu-item routerLink="/mutuals" routerLinkActive="link-active">Mutuals</a>
           <a mat-menu-item routerLink="/color" routerLinkActive="link-active">Color</a>
+          <a mat-menu-item routerLink="/farbduell" routerLinkActive="link-active">Farbduell</a>
         </mat-menu>
       </div>
     </div>

--- a/apps/tehwolfde/src/app/components/nav/mobile/mobile.component.html
+++ b/apps/tehwolfde/src/app/components/nav/mobile/mobile.component.html
@@ -72,6 +72,9 @@
       <a (click)="closeSidenav()" routerLink="/color" routerLinkActive="link-active" mat-list-item>
         <span>Color</span>
       </a>
+      <a (click)="closeSidenav()" routerLink="/farbduell" routerLinkActive="link-active" mat-list-item>
+        <span>Farbduell</span>
+      </a>
       <a
         (click)="closeSidenav()"
         class="mat-mdc-list-item"

--- a/apps/tehwolfde/src/app/embeds/farbduell/farbduell.component.ts
+++ b/apps/tehwolfde/src/app/embeds/farbduell/farbduell.component.ts
@@ -1,0 +1,12 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import { EmbedComponent } from '../embed/embed.component';
+
+@Component({
+  selector: 'tehw0lf-farbduell',
+  standalone: true,
+  imports: [EmbedComponent],
+  template: `<tehw0lf-embed url="https://farbduell.tehwolf.de" title="Farbduell" />`,
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class FarbduellComponent {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
* Introduced a new route for the 'farbduell' feature.
* Added the FarbduellComponent to handle the new route.
* Updated navigation in both desktop and mobile views to include a link to 'farbduell'.
* Incremented version to 0.22.2 in package.json and package-lock.json.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced "Farbduell", a new embedded application accessible through the apps dropdown menu. This feature has been integrated into both desktop and mobile navigation interfaces, enabling users to conveniently access the Farbduell interactive tool from any device.

* **Chores**
  * Version bumped to 0.22.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->