### PR TITLE
chore(zap): add ignore rules for accepted findings

### DIFF
--- a/.github/workflows/dast-scan.yml
+++ b/.github/workflows/dast-scan.yml
@@ -16,3 +16,4 @@ jobs:
     with:
       target_url: "https://tehwolf.de"
       scan_type: "baseline"
+      rules_file: ".zap/rules.tsv"

--- a/.zap/rules.md
+++ b/.zap/rules.md
@@ -1,0 +1,13 @@
+# ZAP DAST Ignore Rules
+
+Rules suppressed in `.zap/rules.tsv` with justification:
+
+| Rule ID | Name | Reason |
+|---------|------|--------|
+| 10035 | Strict-Transport-Security Header Not Set | HSTS is configured in Cloudflare (SSL/TLS → Edge Certificates → HSTS). ZAP scans the HTTP→HTTPS redirect path and does not see the header Cloudflare injects on HTTPS responses. |
+| 10055 | CSP: style-src unsafe-inline / Missing Directives | `style-src unsafe-inline` is required by Angular. `form-action` and `base-uri` are explicitly defined in the CSP — ZAP flags these as informational when `default-src` has no fallback for them. |
+| 10109 | Modern Web Application | Informational finding — ZAP detected a SPA. Not a vulnerability. |
+| 10015 | Re-examine Cache-control Directives | Informational finding about cache headers. Not a vulnerability. |
+| 10049 | Storable and Cacheable Content | Informational finding. Static assets are intentionally cacheable. |
+| 10096 | Timestamp Disclosure - Unix | Build timestamps embedded in JS bundles by the build tool. Not sensitive data. |
+| 10110 | Dangerous JS Functions | `setTimeout`, `setInterval`, and `Function` are used internally by Angular and Zone.js — not by application code. False positive. |

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,0 +1,7 @@
+10035	IGNORE	HSTS not set — handled by Cloudflare at TLS termination, not nginx
+10055	IGNORE	CSP style-src unsafe-inline required by Angular; form-action and base-uri are explicitly set
+10109	IGNORE	Modern Web Application — informational only, not a vulnerability
+10015	IGNORE	Cache-control directives — informational only, not a vulnerability
+10049	IGNORE	Storable and Cacheable Content — informational only, not a vulnerability
+10096	IGNORE	Timestamp Disclosure — build timestamps in JS bundles, not sensitive data
+10110	IGNORE	Dangerous JS Functions — setTimeout/setInterval/Function used internally by Angular and Zone.js, not application code

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.4",
+      "version": "0.22.5",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary

Adds `.zap/rules.tsv` to suppress ZAP findings that are either false positives or accepted risks, and `.zap/rules.md` documenting the justification for each suppression.

See `.zap/rules.md` for full reasoning per rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added DAST security scan rules documentation with suppression justifications.

* **Chores**
  * Updated security scan workflow configuration to use additional rules file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->