### PR TITLE
chore(zap): add Retrieved from Cache to ignore rules

### DIFF
--- a/.zap/rules.md
+++ b/.zap/rules.md
@@ -11,3 +11,4 @@ Rules suppressed in `.zap/rules.tsv` with justification:
 | 10049 | Storable and Cacheable Content | Informational finding. Static assets are intentionally cacheable. |
 | 10096 | Timestamp Disclosure - Unix | Build timestamps embedded in JS bundles by the build tool. Not sensitive data. |
 | 10110 | Dangerous JS Functions | `setTimeout`, `setInterval`, and `Function` are used internally by Angular and Zone.js — not by application code. False positive. |
+| 10050 | Retrieved from Cache | Cloudflare CDN caching behavior. Not a vulnerability. |

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -5,3 +5,4 @@
 10049	IGNORE	Storable and Cacheable Content — informational only, not a vulnerability
 10096	IGNORE	Timestamp Disclosure — build timestamps in JS bundles, not sensitive data
 10110	IGNORE	Dangerous JS Functions — setTimeout/setInterval/Function used internally by Angular and Zone.js, not application code
+10050	IGNORE	Retrieved from Cache — Cloudflare CDN caching behavior, not a vulnerability

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.5",
+  "version": "0.22.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.5",
+      "version": "0.22.6",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.5",
+  "version": "0.22.6",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
Adds rule 10050 (Retrieved from Cache) to ZAP ignore rules — Cloudflare CDN caching behavior, not a vulnerability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.22.5
  * Updated security scan tooling configuration
  * Added security scan suppression rules documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->