### PR TITLE
fix: white border, self-framing CSP, lighthouse URL format

### DIFF
--- a/apps/tehwolfde/src/styles.scss
+++ b/apps/tehwolfde/src/styles.scss
@@ -26,6 +26,8 @@
 
 body {
   height: 100vh;
+  margin: 0;
+  padding: 0;
 }
 
 body.dark {

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,8 +11,8 @@ http {
 
         listen 80;
 
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; form-action 'none'; base-uri 'self';" always;
-        add_header X-Frame-Options "DENY" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
         add_header Cross-Origin-Embedder-Policy "require-corp" always;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.8",
+  "version": "0.22.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.8",
+      "version": "0.22.9",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.8",
+  "version": "0.22.9",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary

- **White border**: Added `margin: 0; padding: 0` to `body` in `styles.scss` — browser default 8px margin was visible as a white frame around the app
- **Framing broken**: Changed CSP `frame-ancestors 'none'` → `'self'` and `X-Frame-Options: DENY` → `SAMEORIGIN` in `nginx.conf` — the home page preview iframes load relative URLs (`/portfolio`, `/wordlist-generator`, `/contact-form`), which resolve to `https://tehwolf.de/...`, so the site was trying to embed itself and its own CSP blocked it
- **Lighthouse `INVALID_URL`**: Fixed by the workflows PR #91 (already merged) — `treosh/lighthouse-ci-action` expects newline-separated URLs, not a JSON array

## Test plan

- [ ] Confirm no white border visible around the app
- [ ] Confirm preview iframes on home page load correctly
- [ ] Confirm Lighthouse scan passes after next scheduled/manual run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted page base spacing so the site now starts with no default browser margin or padding.
  * Updated embedded content protection settings to allow same-site framing while keeping security headers enabled.

* **Chores**
  * Bumped the app version to `0.22.9`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->