### PR TITLE
fix(csp): allow github api, subdomains and unsafe-hashes for icons

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,7 @@ http {
 
         listen 80;
 
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.github.com; frame-src https://*.tehwolf.de https://tehwolf.github.io; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
@@ -31,7 +31,7 @@ http {
             root /usr/share/nginx/html;
             expires 1y;
             add_header Cache-Control "public, immutable";
-            add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.github.com; frame-src https://*.tehwolf.de https://tehwolf.github.io; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
             add_header X-Frame-Options "SAMEORIGIN" always;
             add_header X-Content-Type-Options "nosniff" always;
             add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
@@ -46,7 +46,7 @@ http {
             root /usr/share/nginx/html;
             expires 7d;
             add_header Cache-Control "public";
-            add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.github.com; frame-src https://*.tehwolf.de https://tehwolf.github.io; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
             add_header X-Frame-Options "SAMEORIGIN" always;
             add_header X-Content-Type-Options "nosniff" always;
             add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.10",
+  "version": "0.22.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.10",
+      "version": "0.22.11",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.10",
+  "version": "0.22.11",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary
- Add `https://api.github.com` to `connect-src` so the git-portfolio library can fetch repos
- Add `https://*.tehwolf.de` and `https://tehwolf.github.io` to `frame-src` so preview iframes load
- Add `'unsafe-hashes'` to `script-src` to allow Angular Material inline event handlers (e.g. `this.media='all'` on font stylesheets)

## Test plan
- [ ] Portfolio page loads GitHub repos
- [ ] Preview iframes visible on home page
- [ ] No CSP errors in browser console
- [ ] nginx validate passes locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the app version to **0.22.11**.
* **Changes**
  * Updated browser security policy settings to better support loading scripts, styles, fonts, images, external API requests, and embedded content from approved sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->