### PR TITLE
fix(csp): allow github api, subdomains and unsafe-hashes for icons

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,11 +11,11 @@ http {
 
         listen 80;
 
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.github.com; frame-src https://*.tehwolf.de https://tehwolf.github.io; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.github.com; frame-src https://*.tehwolf.de https://tehwolf.github.io; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-        add_header Cross-Origin-Embedder-Policy "require-corp" always;
+        add_header Cross-Origin-Embedder-Policy "credentialless" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header Cross-Origin-Resource-Policy "same-origin" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
@@ -31,11 +31,11 @@ http {
             root /usr/share/nginx/html;
             expires 1y;
             add_header Cache-Control "public, immutable";
-            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.github.com; frame-src https://*.tehwolf.de https://tehwolf.github.io; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.github.com; frame-src https://*.tehwolf.de https://tehwolf.github.io; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
             add_header X-Frame-Options "SAMEORIGIN" always;
             add_header X-Content-Type-Options "nosniff" always;
             add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-            add_header Cross-Origin-Embedder-Policy "require-corp" always;
+            add_header Cross-Origin-Embedder-Policy "credentialless" always;
             add_header Cross-Origin-Opener-Policy "same-origin" always;
             add_header Cross-Origin-Resource-Policy "same-origin" always;
             add_header Referrer-Policy "strict-origin-when-cross-origin" always;
@@ -46,11 +46,11 @@ http {
             root /usr/share/nginx/html;
             expires 7d;
             add_header Cache-Control "public";
-            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.github.com; frame-src https://*.tehwolf.de https://tehwolf.github.io; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.github.com; frame-src https://*.tehwolf.de https://tehwolf.github.io; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
             add_header X-Frame-Options "SAMEORIGIN" always;
             add_header X-Content-Type-Options "nosniff" always;
             add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-            add_header Cross-Origin-Embedder-Policy "require-corp" always;
+            add_header Cross-Origin-Embedder-Policy "credentialless" always;
             add_header Cross-Origin-Opener-Policy "same-origin" always;
             add_header Cross-Origin-Resource-Policy "same-origin" always;
             add_header Referrer-Policy "strict-origin-when-cross-origin" always;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.11",
+  "version": "0.22.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.11",
+      "version": "0.22.12",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.11",
+  "version": "0.22.12",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary
- Add `https://api.github.com` to `connect-src` so the git-portfolio library can fetch repos
- Add `https://*.tehwolf.de` and `https://tehwolf.github.io` to `frame-src` so preview iframes load
- Add `'unsafe-hashes'` + sha256 hash for Angular Material inline handler (`this.media='all'`)
- Change `Cross-Origin-Embedder-Policy` from `require-corp` to `credentialless` so GitHub Pages iframes are not blocked

## Test plan
- [ ] Portfolio page loads GitHub repos
- [ ] Preview iframes visible on home page
- [ ] No CSP errors in browser console
- [ ] nginx validate passes locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated browser security headers to better align with current content loading and cross-origin embedding behavior.
  - Added a specific script hash to the content security policy for improved compatibility.

- **Chores**
  - Bumped the package version to **0.22.12**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->