### PR TITLE
fix(csp): allow github avatars and subdomains in frame-src

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM nginx:alpine-slim
 RUN apk upgrade --no-cache
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY security-headers.conf /etc/nginx/security-headers.conf
 COPY dist/apps/tehwolfde/browser /usr/share/nginx/html

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,71 +1,16 @@
 events {
-  worker_connections  1024;  ## Default: 1024
+  worker_connections  1024;
 }
 
 http {
 
-    ## use mime types
     include /etc/nginx/mime.types;
 
-     server {
-
-        listen 80;
-
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.github.com; frame-src https://*.tehwolf.de https://tehwolf.github.io; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
-        add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-        add_header Cross-Origin-Embedder-Policy "credentialless" always;
-        add_header Cross-Origin-Opener-Policy "same-origin" always;
-        add_header Cross-Origin-Resource-Policy "same-origin" always;
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-
-        location / {
-            root /usr/share/nginx/html;
-            index  index.html;
-            ## without this our .css are not loaded
-            try_files $uri $uri/ /index.html?$query_string;
-        }
-
-        location ~* \.(js|css)$ {
-            root /usr/share/nginx/html;
-            expires 1y;
-            add_header Cache-Control "public, immutable";
-            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.github.com; frame-src https://*.tehwolf.de https://tehwolf.github.io; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
-            add_header X-Frame-Options "SAMEORIGIN" always;
-            add_header X-Content-Type-Options "nosniff" always;
-            add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-            add_header Cross-Origin-Embedder-Policy "credentialless" always;
-            add_header Cross-Origin-Opener-Policy "same-origin" always;
-            add_header Cross-Origin-Resource-Policy "same-origin" always;
-            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-            access_log off;
-        }
-
-        location ~* \.(?:woff2?|svg|ico|png|jpg|jpeg|gif|webp)$ {
-            root /usr/share/nginx/html;
-            expires 7d;
-            add_header Cache-Control "public";
-            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.github.com; frame-src https://*.tehwolf.de https://tehwolf.github.io; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
-            add_header X-Frame-Options "SAMEORIGIN" always;
-            add_header X-Content-Type-Options "nosniff" always;
-            add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-            add_header Cross-Origin-Embedder-Policy "credentialless" always;
-            add_header Cross-Origin-Opener-Policy "same-origin" always;
-            add_header Cross-Origin-Resource-Policy "same-origin" always;
-            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-            access_log off;
-        }
-    }
-
-    ## enable gzip compression
     gzip on;
     gzip_vary on;
     gzip_min_length 256;
     gzip_proxied any;
-
     gzip_types
-      ## text/html is always compressed : https://nginx.org/en/docs/http/ngx_http_gzip_module.html
       text/plain
       text/css
       text/javascript
@@ -74,4 +19,33 @@ http {
       application/xml
       application/json
       application/ld+json;
+
+     server {
+
+        listen 80;
+
+        include /etc/nginx/security-headers.conf;
+
+        location / {
+            root /usr/share/nginx/html;
+            index  index.html;
+            try_files $uri $uri/ /index.html?$query_string;
+        }
+
+        location ~* \.(js|css)$ {
+            root /usr/share/nginx/html;
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+            include /etc/nginx/security-headers.conf;
+            access_log off;
+        }
+
+        location ~* \.(?:woff2?|svg|ico|png|jpg|jpeg|gif|webp)$ {
+            root /usr/share/nginx/html;
+            expires 7d;
+            add_header Cache-Control "public";
+            include /etc/nginx/security-headers.conf;
+            access_log off;
+        }
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.12",
+  "version": "0.22.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.12",
+      "version": "0.22.13",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.13",
+  "version": "0.22.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.13",
+      "version": "0.22.14",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.13",
+  "version": "0.22.14",
   "license": "MIT",
   "scripts": {
     "ng": "nx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.12",
+  "version": "0.22.13",
   "license": "MIT",
   "scripts": {
     "ng": "nx",

--- a/security-headers.conf
+++ b/security-headers.conf
@@ -1,0 +1,8 @@
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://avatars.githubusercontent.com; connect-src 'self' https://api.github.com; frame-src https://*.tehwolf.de https://*.tehwolf.github.io; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+add_header Cross-Origin-Embedder-Policy "credentialless" always;
+add_header Cross-Origin-Opener-Policy "same-origin" always;
+add_header Cross-Origin-Resource-Policy "same-origin" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;


### PR DESCRIPTION
## Summary
- Add `https://avatars.githubusercontent.com` to `img-src` so GitHub repo avatars load
- Fix `frame-src` to use wildcard `https://*.tehwolf.github.io` for GitHub Pages previews

## Test plan
- [ ] GitHub avatars visible in portfolio
- [ ] Preview iframes for GitHub Pages apps load
- [ ] No CSP errors in browser console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the app version from `0.22.12` to `0.22.13`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->