### PR TITLE
fix(csp): add 'self' to frame-src for embedded app iframes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.14",
+  "version": "0.22.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.14",
+      "version": "0.22.15",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.14",
+  "version": "0.22.15",
   "license": "MIT",
   "scripts": {
     "ng": "nx",

--- a/security-headers.conf
+++ b/security-headers.conf
@@ -1,4 +1,4 @@
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://avatars.githubusercontent.com; connect-src 'self' https://api.github.com; frame-src https://*.tehwolf.de https://*.tehwolf.github.io; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://avatars.githubusercontent.com; connect-src 'self' https://api.github.com; frame-src 'self' https://*.tehwolf.de https://*.tehwolf.github.io; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;


### PR DESCRIPTION
## Summary
- Add `'self'` to `frame-src` so iframes pointing to `tehwolf.de/portfolio` etc. are allowed
- Bump version to 0.22.15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated security headers to allow framing content from the site itself, improving compatibility for embedded views.
* **Chores**
  * Bumped the app version to **0.22.15**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->