### PR TITLE
chore: remove nx cloud integration

### DIFF
--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -34,5 +34,3 @@ jobs:
       platforms: "linux/arm64"
       cyclonedx_ignore_npm_errors: true
       npm_audit_omit_dev: true
-    secrets:
-      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}

--- a/nx.json
+++ b/nx.json
@@ -129,7 +129,6 @@
   "parallel": 4,
   "useInferencePlugins": false,
   "defaultBase": "main",
-  "nxCloudId": "68601eec7715b9977d708964",
   "analytics": false,
   "migrate": {
     "agentic": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.15",
+  "version": "0.22.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.15",
+      "version": "0.22.16",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.15",
+  "version": "0.22.16",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary
- Remove `nxCloudId` from `nx.json`
- Remove `NX_CLOUD_ACCESS_TOKEN` secret from workflow
- Bump version to 0.22.16