### PR TITLE
fix(csp): add tehw0lf.github.io to frame-src and fix iframe height

### DIFF
--- a/apps/tehwolfde/src/styles.scss
+++ b/apps/tehwolfde/src/styles.scss
@@ -26,12 +26,23 @@
   }
 }
 
+html {
+  height: 100%;
+}
+
 body {
-  height: 100vh;
+  height: 100%;
   margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
+}
+
+tehw0lf-root {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  height: 100%;
 }
 
 mat-sidenav-container,

--- a/apps/tehwolfde/src/styles.scss
+++ b/apps/tehwolfde/src/styles.scss
@@ -8,6 +8,7 @@
 
 #main-content {
   outline: none;
+  height: 100%;
 }
 
 .skip-link {
@@ -29,6 +30,14 @@ body {
   height: 100vh;
   margin: 0;
   padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+mat-sidenav-container,
+mat-sidenav-content {
+  flex: 1;
+  height: 100%;
 }
 
 body.dark {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.16",
+  "version": "0.22.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.16",
+      "version": "0.22.17",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.16",
+  "version": "0.22.17",
   "license": "MIT",
   "scripts": {
     "ng": "nx",

--- a/security-headers.conf
+++ b/security-headers.conf
@@ -1,4 +1,4 @@
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://avatars.githubusercontent.com; connect-src 'self' https://api.github.com; frame-src 'self' https://*.tehwolf.de https://*.tehwolf.github.io; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://avatars.githubusercontent.com; connect-src 'self' https://api.github.com; frame-src 'self' https://*.tehwolf.de https://tehw0lf.github.io https://*.tehwolf.github.io; frame-ancestors 'self'; form-action 'none'; base-uri 'self';" always;
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;


### PR DESCRIPTION
## Summary
- Add `https://tehw0lf.github.io` explicitly to `frame-src` (wildcard `*.tehwolf.github.io` doesn't match the root)
- Fix iframe height by propagating `height: 100%` through `body → mat-sidenav-container → mat-sidenav-content → main`
- Bump version to 0.22.17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated page layout so the main content and side navigation areas expand to fill the available vertical space more consistently.
  * Tightened the site security policy for embedded content by removing one allowed frame source.
* **Chores**
  * Bumped the application version to `0.22.17`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->