### PR TITLE
fix(csp): remove COEP to allow GitHub Pages iframes in Firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.17",
+  "version": "0.22.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.17",
+      "version": "0.22.18",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.17",
+  "version": "0.22.18",
   "license": "MIT",
   "scripts": {
     "ng": "nx",

--- a/security-headers.conf
+++ b/security-headers.conf
@@ -2,7 +2,6 @@ add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsaf
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-add_header Cross-Origin-Embedder-Policy "credentialless" always;
 add_header Cross-Origin-Opener-Policy "same-origin" always;
 add_header Cross-Origin-Resource-Policy "same-origin" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;


### PR DESCRIPTION
## Summary
- Remove `Cross-Origin-Embedder-Policy` header — GitHub Pages does not send `Cross-Origin-Resource-Policy` headers, causing Firefox to block iframes with `NS_ERROR_DOM_COEP_FAILED` even with `credentialless` COEP
- `SharedArrayBuffer` is not used on this site so COEP provides no benefit
- Bump version to 0.22.18