### PR TITLE
fix: prevent dead object errors by cleaning up subscriptions on destroy

### DIFF
--- a/apps/tehwolfde/src/app/app.component.ts
+++ b/apps/tehwolfde/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import { NgClass } from '@angular/common';
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router } from '@angular/router';
 import { filter } from 'rxjs';
 
@@ -18,7 +19,7 @@ export class AppComponent {
   constructor() {
     const router = inject(Router);
     router.events
-      .pipe(filter((e) => e instanceof NavigationEnd))
+      .pipe(filter((e) => e instanceof NavigationEnd), takeUntilDestroyed())
       .subscribe(() => {
         const main = document.getElementById('main-content');
         main?.focus();

--- a/apps/tehwolfde/src/app/embeds/embed/embed.component.ts
+++ b/apps/tehwolfde/src/app/embeds/embed/embed.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, input, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, ElementRef, inject, input, ViewChild } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
@@ -23,6 +24,7 @@ export class EmbedComponent {
 
   private sanitizer = inject(DomSanitizer);
   private themeService = inject(ThemeService);
+  private destroyRef = inject(DestroyRef);
 
   safeUrl = computed(() =>
     this.sanitizer.bypassSecurityTrustResourceUrl(this.url())
@@ -31,13 +33,14 @@ export class EmbedComponent {
   private targetOrigin = computed(() => new URL(this.url()).origin);
 
   constructor() {
-    effect(() => {
-      const theme = this.themeService.theme();
-      this.iframeRef?.nativeElement.contentWindow?.postMessage(
-        { type: 'theme', theme },
-        this.targetOrigin()
-      );
-    });
+    toObservable(this.themeService.theme)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((theme) => {
+        this.iframeRef?.nativeElement.contentWindow?.postMessage(
+          { type: 'theme', theme },
+          this.targetOrigin()
+        );
+      });
   }
 
   onIframeLoad(): void {

--- a/apps/tehwolfde/src/app/i18n/translate.service.ts
+++ b/apps/tehwolfde/src/app/i18n/translate.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { toObservable } from '@angular/core/rxjs-interop';
-import { switchMap } from 'rxjs';
+import { catchError, of, switchMap } from 'rxjs';
 
 export type Locale = 'en' | 'de';
 
@@ -14,7 +14,7 @@ export class TranslateService {
 
   constructor() {
     toObservable(this.locale)
-      .pipe(switchMap((locale) => this.http.get<Record<string, string>>(`/assets/i18n/${locale}.json`)))
+      .pipe(switchMap((locale) => this.http.get<Record<string, string>>(`/assets/i18n/${locale}.json`).pipe(catchError(() => of({})))))
       .subscribe((t) => this.translations.set(t));
   }
 

--- a/apps/tehwolfde/src/app/i18n/translate.service.ts
+++ b/apps/tehwolfde/src/app/i18n/translate.service.ts
@@ -1,5 +1,7 @@
-import { effect, inject, Injectable, signal } from '@angular/core';
+import { inject, Injectable, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { switchMap } from 'rxjs';
 
 export type Locale = 'en' | 'de';
 
@@ -11,12 +13,9 @@ export class TranslateService {
   private translations = signal<Record<string, string>>({});
 
   constructor() {
-    effect(() => {
-      const locale = this.locale();
-      this.http
-        .get<Record<string, string>>(`/assets/i18n/${locale}.json`)
-        .subscribe((t) => this.translations.set(t));
-    });
+    toObservable(this.locale)
+      .pipe(switchMap((locale) => this.http.get<Record<string, string>>(`/assets/i18n/${locale}.json`)))
+      .subscribe((t) => this.translations.set(t));
   }
 
   translate(key: string): string {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.18",
+  "version": "0.22.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.18",
+      "version": "0.22.19",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.18",
+  "version": "0.22.19",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary
- `embed.component.ts`: Replace `effect()` with `toObservable().pipe(takeUntilDestroyed())` so the theme subscription stops when the component is destroyed — prevents Firefox "can't access dead object" on the iframe's `contentWindow`
- `translate.service.ts`: Replace nested `subscribe()` in `effect()` with `toObservable().pipe(switchMap())` to cancel previous HTTP request when locale changes
- `app.component.ts`: Add `takeUntilDestroyed()` to the router events subscription
- Bump version to 0.22.19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app stability by preventing background subscriptions from lingering after navigation or component changes.
  * Made theme updates more reliable in embedded content.
  * Improved language loading so switching locales updates translations more consistently.

* **Chores**
  * Updated the app version to **0.22.19**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->