### PR TITLE
fix(git-portfolio): use querySelector('svg') to skip MIT license comment node

### DIFF
--- a/libs/git-portfolio/package.json
+++ b/libs/git-portfolio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tehw0lf/git-portfolio",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "license": "MIT",
   "homepage": "https://github.com/tehw0lf/tehwol.fi.git",
   "repository": {

--- a/libs/git-portfolio/src/lib/octicon.directive.ts
+++ b/libs/git-portfolio/src/lib/octicon.directive.ts
@@ -48,14 +48,14 @@ export class OcticonDirective implements OnInit {
       .catch((err) => console.error(err));
   }
 
-  private insertSvgSafely(element: HTMLElement, svgString: string): Node | null {
+  private insertSvgSafely(element: HTMLElement, svgString: string): Element | null {
     const range = document.createRange();
     range.selectNode(element);
     const fragment = range.createContextualFragment(svgString);
     while (element.firstChild) {
       this.renderer.removeChild(element, element.firstChild);
     }
-    const svgElement = fragment.firstChild;
+    const svgElement = fragment.querySelector('svg');
     if (svgElement) {
       this.renderer.appendChild(element, svgElement);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.21",
+  "version": "0.22.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.21",
+      "version": "0.22.22",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.21",
+  "version": "0.22.22",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary
- `insertSvgSafely` was returning `fragment.firstChild` which is the XML comment node (MIT license header at the top of each SVG file) rather than the actual SVG element
- `setStyle(commentNode, 'fill', color)` crashed with `TypeError: can't access property "fill", t.style is undefined` on the live site
- Fixed by using `fragment.querySelector('svg')` which skips any leading comment or text nodes and returns the SVG element directly
- Return type tightened from `Node | null` to `Element | null`

## Test plan
- [ ] Verify git-portfolio renders icons correctly on tehwolf.de after deploy
- [ ] Check browser console for no `setStyle` errors
- [ ] All 48 tests pass (`npm run test`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved icon rendering to ensure the correct SVG element is selected and displayed.
* **Chores**
  * Bumped package versions for the main project and the git portfolio package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->