### PR TITLE
fix(theme): add mat.core-theme to restore floating label colors

### DIFF
--- a/apps/tehwolfde/src/assets/styles/custom-theme.scss
+++ b/apps/tehwolfde/src/assets/styles/custom-theme.scss
@@ -26,6 +26,7 @@ $light-theme: mat.m2-define-light-theme(
 );
 
 @mixin apply-component-themes($theme) {
+  @include mat.core-theme($theme);
   @include mat.button-theme($theme);
   @include mat.card-theme($theme);
   @include mat.divider-theme($theme);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.22",
+  "version": "0.22.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.22",
+      "version": "0.22.23",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.22",
+  "version": "0.22.23",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary
- The Lighthouse CSS optimization in a previous commit replaced `mat.all-component-colors` / `mat.all-component-themes` with explicit per-component mixins
- `mat.core-theme` was not included — it provides base label, ripple, and pseudo-element colors used by all Material components
- Without it, floating labels in `mat-form-field` became invisible in dark mode (same color as background)

## Test plan
- [ ] Verify contact form floating labels are visible on tehwolf.de after deploy
- [ ] Labels should float upward on focus as before
- [ ] No regression in other Material components (buttons, cards, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Applied core Material theming across light and dark theme modes, improving visual consistency for themed components.
* **Chores**
  * Bumped the app version to **0.22.23**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->