### PR TITLE
fix(theme): restore form-field labels by resetting density and setting label color

### DIFF
--- a/apps/tehwolfde/src/assets/styles/custom-theme.scss
+++ b/apps/tehwolfde/src/assets/styles/custom-theme.scss
@@ -1,5 +1,6 @@
 @use '@angular/material' as mat;
 
+@include mat.core();
 @include mat.elevation-classes();
 @include mat.app-background();
 
@@ -43,6 +44,10 @@ $light-theme: mat.m2-define-light-theme(
 
 .dark {
   @include apply-component-themes($dark-theme);
+  @include mat.form-field-density(0);
+  @include mat.input-density(0);
+  --mat-form-field-filled-label-text-color: #cc7832;
+  --mat-form-field-outlined-label-text-color: #cc7832;
 }
 
 .light {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.23",
+  "version": "0.22.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.23",
+      "version": "0.22.24",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.23",
+  "version": "0.22.24",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary
- `density: -2` in the dark theme sets `--mat-form-field-filled-label-display: none` because there is no vertical space for floating labels at that density — this made labels invisible
- Reset form-field and input density to `0` within `.dark` so labels are shown
- Set `--mat-form-field-filled/outlined-label-text-color` to `#cc7832` to match the existing orange nav/link color scheme
- Added `mat.core()` to initialize the CSS custom property token system required by all Material components

## Test plan
- [ ] Verify contact form labels are visible and orange on tehwolf.de after deploy
- [ ] Verify floating label animation works on focus
- [ ] Verify wordlist generator `*` required indicator is still orange (not yellow)
- [ ] No regression in other Material components