### PR TITLE
perf(main): remove @angular/animations to reduce main bundle by 50KB

### DIFF
--- a/apps/tehwolfde/src/app/app.component.spec.ts
+++ b/apps/tehwolfde/src/app/app.component.spec.ts
@@ -3,7 +3,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 
 import { AppComponent } from './app.component';
@@ -16,7 +15,6 @@ describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        BrowserAnimationsModule, // eslint-disable-line @typescript-eslint/no-deprecated
         MatIconModule,
         MatListModule,
         MatToolbarModule,

--- a/apps/tehwolfde/src/app/components/nav/mobile/mobile.component.spec.ts
+++ b/apps/tehwolfde/src/app/components/nav/mobile/mobile.component.spec.ts
@@ -2,7 +2,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatSidenavModule } from '@angular/material/sidenav';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter, Router } from '@angular/router';
 
 import { SidenavService } from '../sidenav.service';
@@ -22,7 +21,6 @@ describe('MobileComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        BrowserAnimationsModule, // eslint-disable-line @typescript-eslint/no-deprecated
         MatIconModule,
         MatListModule,
         MatSidenavModule,

--- a/apps/tehwolfde/src/app/components/nav/nav.component.spec.ts
+++ b/apps/tehwolfde/src/app/components/nav/nav.component.spec.ts
@@ -3,7 +3,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 
 import { DesktopComponent } from './desktop/desktop.component';
@@ -17,7 +16,6 @@ describe('NavComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        BrowserAnimationsModule, // eslint-disable-line @typescript-eslint/no-deprecated
         MatIconModule,
         MatListModule,
         MatSidenavModule,

--- a/apps/tehwolfde/src/app/showcases/contact-form/contact-form.component.spec.ts
+++ b/apps/tehwolfde/src/app/showcases/contact-form/contact-form.component.spec.ts
@@ -1,6 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-
 import { ContactFormComponent } from './contact-form.component';
 
 describe('ContactFormComponent', () => {
@@ -9,7 +7,7 @@ describe('ContactFormComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ContactFormComponent, NoopAnimationsModule] // eslint-disable-line @typescript-eslint/no-deprecated
+      imports: [ContactFormComponent]
     }).compileComponents();
   });
 

--- a/apps/tehwolfde/src/app/showcases/wordlist-generator/wordlist-generator.component.spec.ts
+++ b/apps/tehwolfde/src/app/showcases/wordlist-generator/wordlist-generator.component.spec.ts
@@ -1,6 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-
 import { WordlistGeneratorComponent } from './wordlist-generator.component';
 
 describe('WordlistGeneratorComponent', () => {
@@ -9,7 +7,7 @@ describe('WordlistGeneratorComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [WordlistGeneratorComponent, NoopAnimationsModule] // eslint-disable-line @typescript-eslint/no-deprecated
+      imports: [WordlistGeneratorComponent]
     }).compileComponents();
   });
 

--- a/apps/tehwolfde/src/main.ts
+++ b/apps/tehwolfde/src/main.ts
@@ -1,8 +1,7 @@
 import { provideHttpClient, withXhr } from '@angular/common/http';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimations } from '@angular/platform-browser/animations';
-import { PreloadAllModules, provideRouter, withPreloading } from '@angular/router';
+import { NoPreloading, provideRouter, withPreloading } from '@angular/router';
 
 import { AppComponent } from './app/app.component';
 import { routes } from './app/app.routes';
@@ -12,11 +11,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideZonelessChangeDetection(),
     SidenavService,
-    // TODO: Migrate to native CSS animations when Angular Material supports it (v23+)
-    // See: https://angular.dev/guide/animations/migration
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    provideAnimations(),
     provideHttpClient(withXhr()),
-    provideRouter(routes, withPreloading(PreloadAllModules))
+    provideRouter(routes, withPreloading(NoPreloading))
   ]
 }).catch((err) => console.error(err));

--- a/libs/contact-form/package.json
+++ b/libs/contact-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tehw0lf/contact-form",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "license": "MIT",
   "homepage": "https://github.com/tehw0lf/tehwol.fi.git",
   "repository": {
@@ -8,7 +8,6 @@
     "url": "git+https://github.com/tehw0lf/tehwol.fi.git"
   },
   "peerDependencies": {
-    "@angular/animations": "22.0.2",
     "@angular/common": "22.0.2",
     "@angular/core": "22.0.2",
     "@angular/forms": "22.0.2",

--- a/libs/contact-form/src/lib/contact-form/contact-form.component.spec.ts
+++ b/libs/contact-form/src/lib/contact-form/contact-form.component.spec.ts
@@ -5,7 +5,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AbstractControl, ReactiveFormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyModule } from '@ngx-formly/core';
 import { FormlyMaterialModule } from '@ngx-formly/material';
 import { of, throwError } from 'rxjs';
@@ -35,7 +34,6 @@ describe('ContactFormComponent', () => {
 
     await TestBed.configureTestingModule({
       imports: [
-        BrowserAnimationsModule, // eslint-disable-line @typescript-eslint/no-deprecated
         ReactiveFormsModule,
         MatFormFieldModule,
         MatInputModule,

--- a/libs/git-portfolio/package.json
+++ b/libs/git-portfolio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tehw0lf/git-portfolio",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "license": "MIT",
   "homepage": "https://github.com/tehw0lf/tehwol.fi.git",
   "repository": {
@@ -8,7 +8,6 @@
     "url": "git+https://github.com/tehw0lf/tehwol.fi.git"
   },
   "peerDependencies": {
-    "@angular/animations": "22.0.2",
     "@angular/cdk": "22.0.2",
     "@angular/common": "22.0.2",
     "@angular/core": "22.0.2",

--- a/libs/wordlist-generator/package.json
+++ b/libs/wordlist-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tehw0lf/wordlist-generator",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "license": "MIT",
   "homepage": "https://github.com/tehw0lf/tehwol.fi.git",
   "repository": {
@@ -8,7 +8,6 @@
     "url": "git+https://github.com/tehw0lf/tehwol.fi.git"
   },
   "peerDependencies": {
-    "@angular/animations": "22.0.2",
     "@angular/cdk": "22.0.2",
     "@angular/common": "22.0.2",
     "@angular/core": "22.0.2",

--- a/libs/wordlist-generator/src/lib/wordlist-generator.component.spec.ts
+++ b/libs/wordlist-generator/src/lib/wordlist-generator.component.spec.ts
@@ -5,7 +5,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { delay, of } from 'rxjs';
 
 import { FileType } from './filetypes';
@@ -32,7 +31,6 @@ describe('WordlistGeneratorComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        BrowserAnimationsModule, // eslint-disable-line @typescript-eslint/no-deprecated
         ReactiveFormsModule,
         MatFormFieldModule,
         MatIconModule,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.26",
+  "version": "0.22.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.26",
+      "version": "0.22.27",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "22.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.25",
+  "version": "0.22.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.25",
+      "version": "0.22.26",
       "license": "MIT",
       "dependencies": {
-        "@angular/animations": "22.0.2",
         "@angular/cdk": "22.0.2",
         "@angular/common": "22.0.2",
         "@angular/compiler": "22.0.2",
@@ -483,22 +482,6 @@
         "@typescript-eslint/utils": "^8.0.0",
         "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
-      }
-    },
-    "node_modules/@angular/animations": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.0.2.tgz",
-      "integrity": "sha512-l9lVG9k+baFMWXNsFUxwmxQaUZMkpkTn3vRpa1hs/vABzT/KnaDeweDtvvkS0NS1RYJenoxhONlMNEWuJ4VR1A==",
-      "deprecated": "@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "22.0.2"
       }
     },
     "node_modules/@angular/build": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.25",
+  "version": "0.22.26",
   "license": "MIT",
   "scripts": {
     "ng": "nx",
@@ -31,7 +31,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "22.0.2",
     "@angular/cdk": "22.0.2",
     "@angular/common": "22.0.2",
     "@angular/compiler": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.26",
+  "version": "0.22.27",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary

- Remove `@angular/animations` dependency — Angular Material 22 no longer requires it
- Drop `provideAnimationsAsync()` from `main.ts` (was deprecated in Angular 20.2 anyway)
- Switch router from `PreloadAllModules` to `NoPreloading` to avoid eagerly loading all lazy chunks
- Remove deprecated `BrowserAnimationsModule`/`NoopAnimationsModule` imports from all spec files
- **Main bundle: 684 kB → 634 kB (−50 kB)**

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run test` — 48/48 tests pass
- [x] `npm run build` — build successful, bundle size reduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed Angular animations support from the app bootstrap and package dependencies.
  * Updated router preloading to disable automatic module preloading.
  * Bumped the app version to **0.22.27** (plus related library version bumps).

* **Tests**
  * Simplified multiple unit test setups by removing animation modules from their test configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->