### PR TITLE
perf: reduce main bundle, fix wordlist-generator button heights

### DIFF
--- a/libs/wordlist-generator/src/lib/wordlist-generator.component.scss
+++ b/libs/wordlist-generator/src/lib/wordlist-generator.component.scss
@@ -1,5 +1,14 @@
 @use '@tehw0lf/mvc';
 
+wordlist-generator .mat-mdc-raised-button {
+  height: 50px !important;
+}
+
+wordlist-generator .mat-mdc-icon-button.mat-mdc-button-base {
+  height: 50px !important;
+  width: 50px !important;
+}
+
 .meta-container {
   max-width: 100vw;
 
@@ -39,24 +48,19 @@
     .choose-format {
       margin: 0 10px 10px 0;
       min-width: 150px;
-      line-height: 36px;
       letter-spacing: normal;
     }
 
     .generate-wordlist {
       margin: 0 10px 10px 0;
       min-width: 150px;
-      line-height: 36px;
       letter-spacing: normal;
       white-space: normal;
-      height: auto;
-      padding: 6px 16px;
     }
 
     .download-wordlist {
       margin: 0 0 10px 0;
       min-width: 150px;
-      line-height: 36px;
       letter-spacing: normal;
     }
   }
@@ -98,6 +102,7 @@
 .mat-mdc-form-field {
   height: 50px !important;
 }
+
 
 .mat-mdc-form-field-infix {
   height: 42px !important;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.27",
+  "version": "0.22.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.27",
+      "version": "0.22.28",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.27",
+  "version": "0.22.28",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary
- Switch router preloading from `PreloadAllModules` to `NoPreloading` (all routes are lazy-loaded and only needed on direct navigation, not for homepage iframe embeds)
- Fix all buttons in `wordlist-generator` to match input field height (50px) using element-scoped CSS overrides

## Version
Bumped to `0.22.28`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized the appearance of Material buttons in the wordlist generator.
  * Adjusted button sizing and spacing for a more consistent layout.

* **Chores**
  * Bumped the application version to `0.22.28`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->