### PR TITLE
fix(wordlist-generator): set button height to 42px to match input fields

### DIFF
--- a/libs/wordlist-generator/package.json
+++ b/libs/wordlist-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tehw0lf/wordlist-generator",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "license": "MIT",
   "homepage": "https://github.com/tehw0lf/tehwol.fi.git",
   "repository": {

--- a/libs/wordlist-generator/src/lib/wordlist-generator.component.scss
+++ b/libs/wordlist-generator/src/lib/wordlist-generator.component.scss
@@ -1,12 +1,12 @@
 @use '@tehw0lf/mvc';
 
 wordlist-generator .mat-mdc-raised-button {
-  height: 50px !important;
+  height: 42px !important;
 }
 
 wordlist-generator .mat-mdc-icon-button.mat-mdc-button-base {
-  height: 50px !important;
-  width: 50px !important;
+  height: 42px !important;
+  width: 42px !important;
 }
 
 .meta-container {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.28",
+  "version": "0.22.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.28",
+      "version": "0.22.29",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.28",
+  "version": "0.22.29",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary
- Buttons were 50px which matched the outer `mat-mdc-form-field` wrapper (includes hidden subscript area), making them appear taller than the visible input border box
- Changed to 42px to match `mat-mdc-text-field-wrapper` — the actual visible input height

## Version
No version bump needed (CSS-only fix on top of 0.22.28).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted button sizing in the wordlist generator for a more compact layout.
  * Reduced the height of raised and icon buttons to better match the interface.
  * Standardized icon button dimensions for a more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->