### PR TITLE
chore: migrate versioning to Angular-aligned 22.0.0

### DIFF
--- a/libs/contact-form/package.json
+++ b/libs/contact-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tehw0lf/contact-form",
-  "version": "0.22.1",
+  "version": "22.0.0",
   "license": "MIT",
   "homepage": "https://github.com/tehw0lf/tehwol.fi.git",
   "repository": {

--- a/libs/git-portfolio/package.json
+++ b/libs/git-portfolio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tehw0lf/git-portfolio",
-  "version": "0.23.3",
+  "version": "22.0.0",
   "license": "MIT",
   "homepage": "https://github.com/tehw0lf/tehwol.fi.git",
   "repository": {

--- a/libs/wordlist-generator/package.json
+++ b/libs/wordlist-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tehw0lf/wordlist-generator",
-  "version": "0.22.2",
+  "version": "22.0.0",
   "license": "MIT",
   "homepage": "https://github.com/tehw0lf/tehwol.fi.git",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.29",
+  "version": "22.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "0.22.29",
+      "version": "22.0.0",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "0.22.29",
+  "version": "22.0.0",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary

- Bumps all packages from `0.22.x`/`0.23.x` to `22.0.0`
- Establishes new versioning scheme: `major.minor` tracks Angular's `major.minor`, `patch` is used for our own fixes and features
- Makes Angular upgrade milestones (e.g. `22.1.x`) immediately visible in package versions

## Test plan

- [x] `npm run lint` passes (warnings only, no errors)
- [x] `npm run test` — 48 tests passed
- [x] `npm run build` — all 4 projects built successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app and several related packages to version `22.0.0`.
  * Kept package metadata aligned across the repository for a consistent release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->