### PR TITLE
chore(ci): ignore ZAP rule 90004 (COEP) with justification

### DIFF
--- a/.zap/rules.md
+++ b/.zap/rules.md
@@ -12,3 +12,4 @@ Rules suppressed in `.zap/rules.tsv` with justification:
 | 10096 | Timestamp Disclosure - Unix | Build timestamps embedded in JS bundles by the build tool. Not sensitive data. |
 | 10110 | Dangerous JS Functions | `setTimeout`, `setInterval`, and `Function` are used internally by Angular and Zone.js — not by application code. False positive. |
 | 10050 | Retrieved from Cache | Cloudflare CDN caching behavior. Not a vulnerability. |
+| 90004 | Cross-Origin-Embedder-Policy Header Missing or Invalid | COEP is intentionally set to `unsafe-none`. Switching to `require-corp` was tested (2026-06-20) and breaks the Workbox service worker's `importScripts()` loading, plus would block the GitHub avatar images and GitHub Pages embeds allowed in the CSP `frame-src`/`img-src`, since those origins don't send `Cross-Origin-Resource-Policy` headers. |

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -6,3 +6,4 @@
 10096	IGNORE	Timestamp Disclosure — build timestamps in JS bundles, not sensitive data
 10110	IGNORE	Dangerous JS Functions — setTimeout/setInterval/Function used internally by Angular and Zone.js, not application code
 10050	IGNORE	Retrieved from Cache — Cloudflare CDN caching behavior, not a vulnerability
+90004	IGNORE	COEP set to unsafe-none intentionally — require-corp breaks the Workbox service worker's importScripts() loading and would block GitHub avatar/Pages embeds lacking CORP headers

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "22.0.2",
+  "version": "22.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "22.0.2",
+      "version": "22.0.3",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "22.0.2",
+  "version": "22.0.3",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary

- Adds ignore rule for ZAP 90004 (Cross-Origin-Embedder-Policy Header Missing or Invalid) to `.zap/rules.tsv`
- `COEP: unsafe-none` is intentionally set — `require-corp` was tested on 2026-06-20 and breaks:
  - Workbox service worker's `importScripts()` loading
  - GitHub avatar images (`avatars.githubusercontent.com`) lacking `Cross-Origin-Resource-Policy` headers
  - GitHub Pages embeds allowed in `frame-src`
- Justification documented in `.zap/rules.md`
- Bumps version to 22.0.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for a security scan finding about a missing or invalid Cross-Origin-Embedder-Policy header, noting the current configuration is intentional.
* **Chores**
  * Bumped the project version to **22.0.3**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->