### PR TITLE
fix(ci): pin action SHAs in security-scan.yml

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Download latest dist artifacts from CI
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           workflow: build-projects.yml
           name: dist
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload artifacts for scanning
         if: hashFiles('dist/**/*') != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: build
           path: dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "22.0.3",
+  "version": "22.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "22.0.3",
+      "version": "22.0.4",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "22.0.3",
+  "version": "22.0.4",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary

- Pins `dawidd6/action-download-artifact` and `actions/upload-artifact` to full 40-character commit SHAs in `security-scan.yml`
- Resolves two Semgrep findings (`github-actions-mutable-action-tag`) that appeared in main CI after merge but not on the PR (semgrep was not yet scanning this file on the branch)
- Bumps version to 22.0.4

## Pinned SHAs

| Action | Tag | SHA |
|--------|-----|-----|
| `dawidd6/action-download-artifact` | v6 | `bf251b5aa9c2f7eeb574a96ee720e24f801b7c11` |
| `actions/upload-artifact` | v4 | `ea165f8d65b6e75b540449e92b4886f43607fa02` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to **22.0.4**.
  * Improved release pipeline security by locking artifact-related actions to fixed revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->