### PR TITLE
fix(git-portfolio): sanitize repo URL to prevent XSS via href

### DIFF
--- a/libs/git-portfolio/src/lib/repo-card/repo-card.component.html
+++ b/libs/git-portfolio/src/lib/repo-card/repo-card.component.html
@@ -16,7 +16,8 @@
         mat-button
         [ngStyle]="buttonStyle()"
         target="_blank"
-        href="{{ gitRepo().homepage || gitRepo().html_url || gitRepo().web_url }}"
+        rel="noopener noreferrer"
+        [href]="repoUrl()"
       >
         {{ gitRepo().name }}
       </a>

--- a/libs/git-portfolio/src/lib/repo-card/repo-card.component.spec.ts
+++ b/libs/git-portfolio/src/lib/repo-card/repo-card.component.spec.ts
@@ -222,6 +222,35 @@ describe('RepoCardComponent', () => {
     });
   });
 
+  describe('repoUrl', () => {
+    it('should return the html_url when it is http(s)', () => {
+      const repo = createMockRepository({ html_url: 'https://github.com/user/test-repo' });
+      fixture.componentRef.setInput('gitRepo', repo);
+      fixture.detectChanges();
+
+      expect(component.repoUrl()).toBe('https://github.com/user/test-repo');
+    });
+
+    it('should reject javascript: URIs to prevent XSS via href', () => {
+      const repo = createMockRepository({
+        homepage: 'javascript:alert(1)',
+        html_url: undefined
+      });
+      fixture.componentRef.setInput('gitRepo', repo);
+      fixture.detectChanges();
+
+      expect(component.repoUrl()).toBeNull();
+    });
+
+    it('should return null when no url is present', () => {
+      const repo = createMockRepository({ html_url: undefined });
+      fixture.componentRef.setInput('gitRepo', repo);
+      fixture.detectChanges();
+
+      expect(component.repoUrl()).toBeNull();
+    });
+  });
+
   describe('edge cases', () => {
     it('should handle repository with null values', () => {
       const repoWithNulls = createMockRepository({

--- a/libs/git-portfolio/src/lib/repo-card/repo-card.component.ts
+++ b/libs/git-portfolio/src/lib/repo-card/repo-card.component.ts
@@ -1,6 +1,6 @@
 import { ClipboardModule } from '@angular/cdk/clipboard';
 import { DatePipe, NgStyle } from '@angular/common';
-import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import * as githubLanguageColors from 'github-language-colors/colors.json';
@@ -51,4 +51,21 @@ export class RepoCardComponent {
   copiedToClipboard = output<boolean>();
 
   githubLanguageColors = githubLanguageColors as Dictionary;
+
+  repoUrl = computed(() => {
+    const url =
+      this.gitRepo().homepage ||
+      this.gitRepo().html_url ||
+      this.gitRepo().web_url ||
+      '';
+
+    try {
+      const parsed = new URL(url);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+        ? url
+        : null;
+    } catch {
+      return null;
+    }
+  });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "22.0.4",
+  "version": "22.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "22.0.4",
+      "version": "22.0.5",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "22.0.4",
+  "version": "22.0.5",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary
- The repo card's title link bound `homepage || html_url || web_url` (fields sourced directly from the GitHub/GitLab API) into `href` via string interpolation, bypassing Angular's URL sanitizer. A repo owner could set `homepage` to a `javascript:` URI, executing script in the visitor's context on click.
- Added a `repoUrl` computed signal that validates the URL scheme (only `http:`/`https:` pass), and switched the template to `[href]` property binding so Angular's built-in URL `SecurityContext` also applies as defense in depth.
- Added `rel="noopener noreferrer"` alongside the existing `target="_blank"` (tabnabbing hardening, same category of fix).
- Resolves Semgrep finding `generic.html-templates.security.var-in-href.var-in-href`.

## Test plan
- [x] `nx run-many -t lint,test,build --projects=git-portfolio,tehwolfde` passes locally
- [x] Added unit tests: valid https URL passes through, `javascript:` URI is rejected, missing URL returns null
- [ ] CI passes