### PR TITLE
feat(tehwolfde): embed WoWQuote2 Manager as new app tile

### DIFF
--- a/apps/tehwolfde/src/app/app.routes.ts
+++ b/apps/tehwolfde/src/app/app.routes.ts
@@ -61,6 +61,13 @@ export const routes: Routes = [
       )
   },
   {
+    path: 'wowquote2-manager',
+    loadComponent: () =>
+      import('./embeds/wowquote2-manager/wowquote2-manager.component').then(
+        (m) => m.WoWQuote2ManagerComponent
+      )
+  },
+  {
     path: 'btrain',
     loadComponent: () =>
       import('./embeds/btrain/btrain.component').then((m) => m.BtrainComponent)

--- a/apps/tehwolfde/src/app/components/nav/desktop/desktop.component.html
+++ b/apps/tehwolfde/src/app/components/nav/desktop/desktop.component.html
@@ -64,6 +64,7 @@
           <a mat-menu-item routerLink="/beep" routerLinkActive="link-active">Beep</a>
           <a mat-menu-item routerLink="/btrain" routerLinkActive="link-active">BTrain</a>
           <a mat-menu-item routerLink="/mutuals" routerLinkActive="link-active">Mutuals</a>
+          <a mat-menu-item routerLink="/wowquote2-manager" routerLinkActive="link-active">WoWQuote2 Manager</a>
           <a mat-menu-item routerLink="/color" routerLinkActive="link-active">Color</a>
           <a mat-menu-item routerLink="/farbduell" routerLinkActive="link-active">Farbduell</a>
         </mat-menu>

--- a/apps/tehwolfde/src/app/components/nav/mobile/mobile.component.html
+++ b/apps/tehwolfde/src/app/components/nav/mobile/mobile.component.html
@@ -69,6 +69,9 @@
       <a (click)="closeSidenav()" routerLink="/mutuals" routerLinkActive="link-active" mat-list-item>
         <span>Mutuals</span>
       </a>
+      <a (click)="closeSidenav()" routerLink="/wowquote2-manager" routerLinkActive="link-active" mat-list-item>
+        <span>WoWQuote2 Manager</span>
+      </a>
       <a (click)="closeSidenav()" routerLink="/color" routerLinkActive="link-active" mat-list-item>
         <span>Color</span>
       </a>

--- a/apps/tehwolfde/src/app/embeds/wowquote2-manager/wowquote2-manager.component.ts
+++ b/apps/tehwolfde/src/app/embeds/wowquote2-manager/wowquote2-manager.component.ts
@@ -1,0 +1,12 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import { EmbedComponent } from '../embed/embed.component';
+
+@Component({
+  selector: 'tehw0lf-wowquote2-manager',
+  standalone: true,
+  imports: [EmbedComponent],
+  template: `<tehw0lf-embed url="https://tehw0lf.github.io/WoWQuote2-Manager/" title="WoWQuote2 Manager" />`,
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class WoWQuote2ManagerComponent {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "22.0.5",
+  "version": "22.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "22.0.5",
+      "version": "22.0.6",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "22.0.5",
+  "version": "22.0.6",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary
- Adds `WoWQuote2ManagerComponent`, following the existing beep/mutuals embed pattern (thin wrapper around the shared `EmbedComponent`)
- Registers the lazy-loaded `/wowquote2-manager` route
- Adds nav entries to both desktop and mobile navigation (Apps dropdown / sidenav)
- Bumps `package.json` version (required for `nx affected` Docker artifact tagging in CI)

No CSP changes needed — `https://tehw0lf.github.io` is already whitelisted in `frame-src` in `security-headers.conf`.

The embedded app (https://tehw0lf.github.io/WoWQuote2-Manager/) already has its own CI security scanning (Semgrep/npm audit/Trivy) and SHA-pinned actions, set up in a separate PR on that repo.

## Test plan
- [x] `npx nx run-many -t lint,test,build --projects=tehwolfde` — all green (48/48 tests, build succeeds, only pre-existing lint warnings)
- [x] Verified locally via Playwright against `nx serve`: `/wowquote2-manager` renders the iframe with the correct `src` and title, no console errors
- [x] Verified nav dropdown entry appears and navigates correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **WoWQuote2 Manager** page, available through a dedicated route.
  * Included the new page in both desktop and mobile navigation menus for easier access.
* **Bug Fixes**
  * Navigation now highlights the WoWQuote2 Manager entry when it’s active.
  * Mobile navigation closes after selecting the new page.
* **Chores**
  * Updated the app version to **22.0.6**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->