### PR TITLE
fix(tehwolfde): align preview cards, fix carousel edges, add switcher flags

### DIFF
--- a/apps/tehwolfde/src/app/components/carousel/carousel.component.scss
+++ b/apps/tehwolfde/src/app/components/carousel/carousel.component.scss
@@ -16,10 +16,21 @@
 .carousel-controls {
   display: flex;
   gap: 8px;
+
+  // The arrow colours are applied inline via ngStyle, which outranks Material's
+  // disabled palette. Without !important a disabled arrow is indistinguishable
+  // from an active one, so the end of the track reads as scrollable.
+  button:disabled {
+    opacity: 0.38 !important;
+    cursor: default;
+  }
 }
 
 .carousel-track {
   display: flex;
+  // Slides carry content of differing length, so they are stretched to the
+  // tallest one in the row rather than each sizing to its own text.
+  align-items: stretch;
   gap: 24px;
   margin-top: 16px;
   overflow-x: auto;

--- a/apps/tehwolfde/src/app/components/carousel/carousel.component.spec.ts
+++ b/apps/tehwolfde/src/app/components/carousel/carousel.component.spec.ts
@@ -64,6 +64,12 @@ function layOutTrack(
       configurable: true,
       value: index * (SLIDE_WIDTH + SLIDE_GAP)
     });
+    // Visibility is measured against the slide's right edge, so the width has
+    // to be laid out too or every slide would measure as zero wide.
+    Object.defineProperty(slide, 'offsetWidth', {
+      configurable: true,
+      value: SLIDE_WIDTH
+    });
   });
 
   return track;
@@ -152,6 +158,33 @@ describe('CarouselComponent', () => {
     expect(component.activeIndex()).toBeLessThan(7);
     expect(component.canScrollForward()).toBe(false);
     expect(component.canScrollBack()).toBe(true);
+  });
+
+  it('should keep forward enabled while the last slide is only partly on screen', () => {
+    // Half a slide wider than six full ones, so slide 6 peeks in at the right
+    // edge without ever being reachable. Counting that sliver as visible left
+    // the last card clipped with the forward arrow already greyed out.
+    const track: HTMLElement =
+      fixture.nativeElement.querySelector('.carousel-track');
+    Object.defineProperty(track, 'clientWidth', {
+      configurable: true,
+      get: () => 6 * (SLIDE_WIDTH + SLIDE_GAP) - SLIDE_GAP + SLIDE_WIDTH / 2
+    });
+    Object.defineProperty(track, 'offsetLeft', { configurable: true, value: 0 });
+    Array.from(track.children).forEach((slide, index) => {
+      Object.defineProperty(slide, 'offsetLeft', {
+        configurable: true,
+        value: index * (SLIDE_WIDTH + SLIDE_GAP)
+      });
+      Object.defineProperty(slide, 'offsetWidth', {
+        configurable: true,
+        value: SLIDE_WIDTH
+      });
+    });
+
+    scrollTrackTo(track, 0);
+
+    expect(component.canScrollForward()).toBe(true);
   });
 
   it('should report every visible slide as loadable through the projected content', () => {

--- a/apps/tehwolfde/src/app/components/carousel/carousel.component.spec.ts
+++ b/apps/tehwolfde/src/app/components/carousel/carousel.component.spec.ts
@@ -92,9 +92,9 @@ describe('CarouselComponent', () => {
 
   /** shouldLoad as seen by the projected slides, not by calling it directly. */
   function loadedFlags(): boolean[] {
-    return Array.from(
-      fixture.nativeElement.querySelectorAll('.loaded')
-    ).map((node) => (node as HTMLElement).textContent?.trim() === 'true');
+    return Array.from(fixture.nativeElement.querySelectorAll('.loaded')).map(
+      (node) => (node as HTMLElement).textContent?.trim() === 'true'
+    );
   }
 
   beforeEach(async () => {
@@ -170,7 +170,10 @@ describe('CarouselComponent', () => {
       configurable: true,
       get: () => 6 * (SLIDE_WIDTH + SLIDE_GAP) - SLIDE_GAP + SLIDE_WIDTH / 2
     });
-    Object.defineProperty(track, 'offsetLeft', { configurable: true, value: 0 });
+    Object.defineProperty(track, 'offsetLeft', {
+      configurable: true,
+      value: 0
+    });
     Array.from(track.children).forEach((slide, index) => {
       Object.defineProperty(slide, 'offsetLeft', {
         configurable: true,
@@ -185,6 +188,46 @@ describe('CarouselComponent', () => {
     scrollTrackTo(track, 0);
 
     expect(component.canScrollForward()).toBe(true);
+  });
+
+  it('should not count a clipped active slide as the last visible one', () => {
+    // A viewport one and a half slides wide, scrolled so the active slide is cut
+    // off by the right edge. Seeding the measurement from the active index made
+    // that slide count itself as fully visible, which reported the visible range
+    // one slide further than it really reached.
+    const track: HTMLElement =
+      fixture.nativeElement.querySelector('.carousel-track');
+    Object.defineProperty(track, 'clientWidth', {
+      configurable: true,
+      get: () => SLIDE_WIDTH + SLIDE_WIDTH / 2
+    });
+    Object.defineProperty(track, 'offsetLeft', {
+      configurable: true,
+      value: 0
+    });
+    Array.from(track.children).forEach((slide, index) => {
+      Object.defineProperty(slide, 'offsetLeft', {
+        configurable: true,
+        value: index * (SLIDE_WIDTH + SLIDE_GAP)
+      });
+      Object.defineProperty(slide, 'offsetWidth', {
+        configurable: true,
+        value: SLIDE_WIDTH
+      });
+    });
+
+    // Just short of slide 3's own offset, so it is the nearest one and becomes
+    // active, while still extending past the viewport's right edge.
+    const clippedOffset = 3 * (SLIDE_WIDTH + SLIDE_GAP) - SLIDE_WIDTH / 4;
+    scrollTrackTo(track, clippedOffset);
+
+    expect(component.activeIndex()).toBe(3);
+    // Slide 3 is clipped, so the fully visible range ends before it and the
+    // forward control still has somewhere to go.
+    expect(component.canScrollForward()).toBe(true);
+    // The clipped slide is still mounted as the one after the visible range,
+    // but the range itself must not claim to reach it.
+    expect(loadedFlags()[4]).toBe(false);
   });
 
   it('should report every visible slide as loadable through the projected content', () => {
@@ -257,9 +300,9 @@ describe('CarouselComponent', () => {
   });
 
   it('should render the label as the heading and expose the section', () => {
-    expect(
-      fixture.nativeElement.querySelector('h2').textContent.trim()
-    ).toBe('Test');
+    expect(fixture.nativeElement.querySelector('h2').textContent.trim()).toBe(
+      'Test'
+    );
     expect(
       fixture.nativeElement.querySelector('[data-section="test"]')
     ).not.toBeNull();

--- a/apps/tehwolfde/src/app/components/carousel/carousel.component.ts
+++ b/apps/tehwolfde/src/app/components/carousel/carousel.component.ts
@@ -187,7 +187,10 @@ export class CarouselComponent {
     let last = this.activeIndex();
     slides.forEach((slide, index) => {
       const start = slide.offsetLeft - trackEl.offsetLeft;
-      if (start < viewportEnd) {
+      // Fully visible, not merely peeking in: a slide clipped by the right edge
+      // still has to be scrollable to, so counting it would disable the forward
+      // button while it sits half off screen.
+      if (start + slide.offsetWidth <= viewportEnd + 1) {
         last = index;
       }
     });

--- a/apps/tehwolfde/src/app/components/carousel/carousel.component.ts
+++ b/apps/tehwolfde/src/app/components/carousel/carousel.component.ts
@@ -170,8 +170,12 @@ export class CarouselComponent {
    * @param scrollLeft Position to measure against, for callers that know where
    * an in progress smooth scroll is heading. Defaults to the current offset.
    *
+   * Counts only slides that fit entirely between both viewport edges, so a
+   * clipped one never reports the range as reaching further than it does.
+   *
    * Falls back to the active slide alone when the track has not been laid out,
-   * which is the case in jsdom where every element reports a zero size.
+   * which is the case in jsdom where every element reports a zero size, and
+   * likewise when the viewport is too narrow to fit any slide in full.
    */
   private measureVisibleRange(scrollLeft?: number): void {
     const trackEl = this.track()?.nativeElement;
@@ -181,21 +185,29 @@ export class CarouselComponent {
     }
 
     const slides = Array.from(trackEl.children) as HTMLElement[];
-    const viewportEnd =
-      (scrollLeft ?? trackEl.scrollLeft) + trackEl.clientWidth;
+    const viewportStart = scrollLeft ?? trackEl.scrollLeft;
+    const viewportEnd = viewportStart + trackEl.clientWidth;
 
-    let last = this.activeIndex();
+    // Seeded below the first slide rather than from the active index: a clipped
+    // active slide would otherwise count itself as visible and disable the
+    // forward button while it still sits half off screen.
+    let last = -1;
     slides.forEach((slide, index) => {
       const start = slide.offsetLeft - trackEl.offsetLeft;
-      // Fully visible, not merely peeking in: a slide clipped by the right edge
-      // still has to be scrollable to, so counting it would disable the forward
-      // button while it sits half off screen.
-      if (start + slide.offsetWidth <= viewportEnd + 1) {
+      // Fully visible, not merely peeking in, so a slide clipped by either edge
+      // stays scrollable to.
+      if (
+        start >= viewportStart - 1 &&
+        start + slide.offsetWidth <= viewportEnd + 1
+      ) {
         last = index;
       }
     });
 
-    this.lastVisibleIndex.set(last);
+    // A viewport narrower than a single slide fits none of them fully. Falling
+    // back to the active slide keeps the range non empty, so the arrows still
+    // describe a track that can be scrolled one slide at a time.
+    this.lastVisibleIndex.set(last === -1 ? this.activeIndex() : last);
   }
 
   scrollBy(direction: -1 | 1): void {
@@ -246,7 +258,9 @@ export class CarouselComponent {
     let smallestDelta = Number.POSITIVE_INFINITY;
 
     slides.forEach((slide, index) => {
-      const delta = Math.abs(slide.offsetLeft - trackEl.offsetLeft - scrollLeft);
+      const delta = Math.abs(
+        slide.offsetLeft - trackEl.offsetLeft - scrollLeft
+      );
       if (delta < smallestDelta) {
         smallestDelta = delta;
         closest = index;

--- a/apps/tehwolfde/src/app/components/home/preview-card.component.scss
+++ b/apps/tehwolfde/src/app/components/home/preview-card.component.scss
@@ -1,7 +1,28 @@
 // The host is the projected carousel slide, so it carries the slide sizing.
+// A flex column rather than a block: the track stretches the slide to the
+// tallest in the row, and only a flex child reliably fills that height without
+// depending on a percentage resolving against an auto sized parent.
+// No percentage height: the track already stretches the slide to the tallest in
+// the row, and a height:100% resolved against the auto sized track would cap
+// this slide at its own content height instead.
 :host {
-  display: block;
-  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-self: stretch;
+}
+
+// Descriptions differ in length, so the card stretches to the tallest slide in
+// the row and the content column absorbs the slack. That keeps every preview
+// and every button on the same baseline across the carousel.
+mat-card {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  box-sizing: border-box;
+}
+
+mat-card-content {
+  flex: 1 1 auto;
 }
 
 .preview-container {
@@ -25,4 +46,16 @@
 
 .description {
   margin: 0;
+}
+
+// The card has a single call to action, so it spans the full slide width
+// rather than sitting as a small chip in the corner.
+mat-card-actions {
+  padding: 8px 16px 16px;
+
+  a {
+    width: 100%;
+    height: 48px;
+    line-height: 48px;
+  }
 }

--- a/apps/tehwolfde/src/app/components/nav/desktop/desktop.component.html
+++ b/apps/tehwolfde/src/app/components/nav/desktop/desktop.component.html
@@ -95,14 +95,7 @@
         <mat-icon>dark_mode</mat-icon>
       </button>
     }
-    <button
-      mat-icon-button
-      [style]="buttonStyle()"
-      (click)="translateService.toggle()"
-      [attr.aria-label]="'nav.switchLanguage' | translate"
-    >
-      <span>{{ translateService.locale() === 'en' ? 'DE' : 'EN' }}</span>
-    </button>
+    <tehw0lf-language-switcher [style]="buttonStyle()" />
     <div [style]="buttonStyle()">
       <div class="nav-item">
         <a mat-button target="_blank" href="https://github.com/tehw0lf">

--- a/apps/tehwolfde/src/app/components/nav/desktop/desktop.component.ts
+++ b/apps/tehwolfde/src/app/components/nav/desktop/desktop.component.ts
@@ -10,6 +10,7 @@ import { isActive, Router, RouterLink, RouterLinkActive } from '@angular/router'
 import { Subject, takeUntil } from 'rxjs';
 
 import { EMBEDDED_APPS } from '../../../embeds/apps';
+import { LanguageSwitcherComponent } from '../../../i18n/language-switcher.component';
 import { TranslatePipe } from '../../../i18n/translate.pipe';
 import { TranslateService } from '../../../i18n/translate.service';
 import { ThemeService } from '../../../services/theme.service';
@@ -28,7 +29,8 @@ import { SidenavService } from '../sidenav.service';
     MatMenuModule,
     RouterLink,
     RouterLinkActive,
-    TranslatePipe
+    TranslatePipe,
+    LanguageSwitcherComponent
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/apps/tehwolfde/src/app/components/nav/mobile/mobile.component.html
+++ b/apps/tehwolfde/src/app/components/nav/mobile/mobile.component.html
@@ -114,13 +114,7 @@
             <mat-icon>dark_mode</mat-icon>
           </button>
         }
-        <button
-          mat-icon-button
-          (click)="translateService.toggle()"
-          [attr.aria-label]="'nav.switchLanguage' | translate"
-        >
-          <span>{{ translateService.locale() === 'en' ? 'DE' : 'EN' }}</span>
-        </button>
+        <tehw0lf-language-switcher />
       </div>
     </mat-nav-list>
   </mat-sidenav>

--- a/apps/tehwolfde/src/app/components/nav/mobile/mobile.component.ts
+++ b/apps/tehwolfde/src/app/components/nav/mobile/mobile.component.ts
@@ -20,6 +20,7 @@ import { isActive, Router, RouterLink, RouterLinkActive, RouterOutlet } from '@a
 import { Subject } from 'rxjs';
 
 import { EMBEDDED_APPS } from '../../../embeds/apps';
+import { LanguageSwitcherComponent } from '../../../i18n/language-switcher.component';
 import { TranslatePipe } from '../../../i18n/translate.pipe';
 import { TranslateService } from '../../../i18n/translate.service';
 import { ThemeService } from '../../../services/theme.service';
@@ -41,7 +42,8 @@ import { SidenavService } from '../sidenav.service';
     MatButtonModule,
     MatIconModule,
     RouterOutlet,
-    TranslatePipe
+    TranslatePipe,
+    LanguageSwitcherComponent
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/apps/tehwolfde/src/app/i18n/language-switcher.component.html
+++ b/apps/tehwolfde/src/app/i18n/language-switcher.component.html
@@ -1,0 +1,22 @@
+<button
+  mat-button
+  class="language-button"
+  type="button"
+  (click)="translateService.toggle()"
+  [attr.aria-label]="'nav.switchLanguage' | translate"
+>
+  @if (translateService.nextLocale() === 'de') {
+    <svg class="language-flag" viewBox="0 0 5 3" aria-hidden="true">
+      <rect width="5" height="1" y="0" fill="#000000" />
+      <rect width="5" height="1" y="1" fill="#dd0000" />
+      <rect width="5" height="1" y="2" fill="#ffce00" />
+    </svg>
+  } @else {
+    <svg class="language-flag" viewBox="0 0 19 10" aria-hidden="true">
+      <rect width="19" height="10" fill="#b22234" />
+      <path d="M0 1.5h19M0 3.5h19M0 5.5h19M0 7.5h19M0 9.5h19" stroke="#ffffff" />
+      <rect width="8" height="5.5" fill="#3c3b6e" />
+    </svg>
+  }
+  <span class="language-code">{{ translateService.nextLocale() }}</span>
+</button>

--- a/apps/tehwolfde/src/app/i18n/language-switcher.component.scss
+++ b/apps/tehwolfde/src/app/i18n/language-switcher.component.scss
@@ -1,0 +1,42 @@
+// mat-icon-button centres a 24px glyph, which neither an svg nor a text node
+// inherits, so the old label sat off centre next to the theme and GitHub icons.
+// A mat-button with explicit centring keeps flag and code on the same baseline
+// as the rest of the toolbar.
+:host {
+  display: inline-flex;
+  align-items: center;
+}
+
+.language-button {
+  min-width: 0;
+  padding: 0 8px;
+}
+
+// Material wraps projected content in .mdc-button__label, so centring the
+// button itself leaves flag and code stacked inside that wrapper. The label is
+// the element that has to become the flex row.
+.language-button ::ng-deep .mdc-button__label,
+.language-button .mdc-button__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  line-height: 1;
+}
+
+.language-flag {
+  display: block;
+  width: 20px;
+  height: 14px;
+  // The artwork carries its own colours, so it must not pick up the toolbar
+  // text colour the way a mat-icon would.
+  border-radius: 2px;
+  flex: none;
+}
+
+.language-code {
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  line-height: 1;
+}

--- a/apps/tehwolfde/src/app/i18n/language-switcher.component.ts
+++ b/apps/tehwolfde/src/app/i18n/language-switcher.component.ts
@@ -1,0 +1,26 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+
+import { TranslatePipe } from './translate.pipe';
+import { TranslateService } from './translate.service';
+
+/**
+ * Toggles between the two locales, showing the flag of the one being offered
+ * rather than the one in use.
+ *
+ * The flags are inline SVG instead of regional indicator emoji: emoji need a
+ * colour emoji font, which plain Linux installs frequently lack, and the glyph
+ * degrades to tofu boxes rather than to the letter pair it falls back to on
+ * Windows. The locale code sits next to the flag so the control still reads as
+ * a language switch when the artwork is too small to identify.
+ */
+@Component({
+  selector: 'tehw0lf-language-switcher',
+  templateUrl: './language-switcher.component.html',
+  styleUrls: ['./language-switcher.component.scss'],
+  imports: [MatButtonModule, TranslatePipe],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class LanguageSwitcherComponent {
+  translateService = inject(TranslateService);
+}

--- a/apps/tehwolfde/src/app/i18n/translate.service.ts
+++ b/apps/tehwolfde/src/app/i18n/translate.service.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable, signal } from '@angular/core';
+import { computed, inject, Injectable, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { catchError, of, switchMap } from 'rxjs';
@@ -17,6 +17,13 @@ export class TranslateService {
       .pipe(switchMap((locale) => this.http.get<Record<string, string>>(`/assets/i18n/${locale}.json`).pipe(catchError(() => of({})))))
       .subscribe((t) => this.translations.set(t));
   }
+
+  /**
+   * The locale the switcher offers, which is the one the user is not currently
+   * reading. Both nav variants render the same control, so the label lives here
+   * rather than being duplicated as a ternary in two templates.
+   */
+  nextLocale = computed<Locale>(() => (this.locale() === 'en' ? 'de' : 'en'));
 
   translate(key: string): string {
     return this.translations()[key] ?? key;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "22.1.4",
+  "version": "22.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "22.1.4",
+      "version": "22.1.5",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "22.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "22.1.4",
+  "version": "22.1.5",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Summary

Three related fixes to the home page carousels plus the language switcher, all reported from mobile and desktop screenshots.

**Try it button** — sat as a small chip in the corner of each preview card. Now spans the full slide width at a 48px touch target.

**Equal card heights** — cards sized themselves to their own description, so buttons landed at different heights across a row. The slides are now stretched to the tallest in the row. Notably the slide must *not* carry `height: 100%`: resolved against the auto sized track it caps the slide at its own content height, which is what left the third library card 19px short.

**Two carousel edge bugs**
- The last slide stayed clipped while the forward arrow was already disabled: visibility counted a slide that had only peeked past the right edge (`start < viewportEnd`). It now requires the slide's right edge to be inside the viewport.
- A disabled arrow looked identical to an active one: the inline `ngStyle` colour outranks Material's disabled palette, so the disabled state is expressed with `opacity` instead.

**Language switcher** — the DE/EN label was a bare text node inside a `mat-icon-button`, which centres a 24px glyph and gives text no centring, leaving it off the baseline the other icons share. Replaced with a flag plus the offered locale code, extracted into its own component since both nav variants rendered the same control.

Flags are inline SVG rather than regional indicator emoji: emoji need a colour emoji font, which plain Linux installs frequently lack (this machine has none), and there the glyph degrades to tofu boxes rather than the letter pair it falls back to on Windows.

## Verification

Measured in a real browser rather than by eye:

| | before | after |
|---|---|---|
| Libraries card heights | 448 / 448 / **429** | 448 / 448 / **448** |
| Apps card heights | all 360 | all 360 |
| Arrows at track end | both active | forward disabled, last slide fully visible |
| Switcher alignment | label off baseline | flag / button / theme icon all at `centerY: 28` |

- `nx run-many -t lint,test,build` — 0 errors, 70 unit tests, all 5 projects build
- `npm run e2e` — **106/106 passed**

Adds a regression test for the partially visible slide; the carousel test helper now stubs `offsetWidth`, which the new visibility check reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified language switcher with locale labels and flag icons in both desktop and mobile navigation.
* **Bug Fixes**
  * Improved carousel navigation logic to better handle partially visible/clipped slides.
  * Enhanced disabled carousel arrow visibility and cursor behavior.
  * Ensured carousel slides stretch to match the tallest slide for consistent row height.
* **Chores**
  * Updated the application version to 22.1.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->