### PR TITLE
fix(tehwolfde): make the language switcher reachable and cover it with tests

### DIFF
--- a/apps/tehwolfde/src/app/components/carousel/carousel.component.spec.ts
+++ b/apps/tehwolfde/src/app/components/carousel/carousel.component.spec.ts
@@ -58,6 +58,12 @@ function layOutTrack(
     get: () => visibleSlides * (SLIDE_WIDTH + SLIDE_GAP) - SLIDE_GAP
   });
   Object.defineProperty(track, 'offsetLeft', { configurable: true, value: 0 });
+  // scrollTo clamps its target against the real end of the track, so the
+  // scrollable width has to be laid out as well.
+  Object.defineProperty(track, 'scrollWidth', {
+    configurable: true,
+    get: () => track.children.length * (SLIDE_WIDTH + SLIDE_GAP) - SLIDE_GAP
+  });
 
   Array.from(track.children).forEach((slide, index) => {
     Object.defineProperty(slide, 'offsetLeft', {
@@ -158,6 +164,24 @@ describe('CarouselComponent', () => {
     expect(component.activeIndex()).toBeLessThan(7);
     expect(component.canScrollForward()).toBe(false);
     expect(component.canScrollBack()).toBe(true);
+  });
+
+  it('should record the slide the track can actually reach at the end', () => {
+    // Six of eight slides fit, so the track stops two slides short of slide 7.
+    // Recording the requested index anyway left activeIndex on a slide never
+    // reached, and the next step back moved by the difference rather than by a
+    // full slide.
+    const track = layOutTrack(fixture, 6);
+
+    component.scrollTo(7);
+
+    expect(component.activeIndex()).toBe(2);
+
+    // Stepping back from the real position lands on the previous slide rather
+    // than jumping into the middle of the track.
+    component.scrollBy(-1);
+    expect(component.activeIndex()).toBe(1);
+    expect(track).toBeTruthy();
   });
 
   it('should keep forward enabled while the last slide is only partly on screen', () => {

--- a/apps/tehwolfde/src/app/components/carousel/carousel.component.ts
+++ b/apps/tehwolfde/src/app/components/carousel/carousel.component.ts
@@ -216,10 +216,10 @@ export class CarouselComponent {
 
   scrollTo(index: number): void {
     const clamped = Math.max(0, Math.min(index, this.itemCount() - 1));
-    this.activeIndex.set(clamped);
 
     const trackEl = this.track()?.nativeElement;
     if (!trackEl) {
+      this.activeIndex.set(clamped);
       this.measureVisibleRange();
       return;
     }
@@ -228,12 +228,25 @@ export class CarouselComponent {
     // Guarded because jsdom and older engines do not implement scrollIntoView.
     slide?.scrollIntoView?.({ block: 'nearest', inline: 'start' });
 
+    // The browser stops at the end of the track, so the last slides all settle
+    // at the same offset. Recording the requested index there would leave
+    // activeIndex on a slide the track never reached, and the next step back
+    // would move by the difference rather than by a full slide.
+    const target = slide ? slide.offsetLeft - trackEl.offsetLeft : undefined;
+    const maxScroll = Math.max(0, trackEl.scrollWidth - trackEl.clientWidth);
+    const reached =
+      target === undefined ? target : Math.min(target, maxScroll);
+
+    this.activeIndex.set(
+      reached === undefined || reached === target
+        ? clamped
+        : this.indexAtOffset(trackEl, reached)
+    );
+
     // Smooth scrolling settles asynchronously, so scrollLeft still holds the old
     // value here. Measuring from where the slide is heading mounts the previews
     // it brings into view immediately rather than one scroll event later.
-    this.measureVisibleRange(
-      slide ? slide.offsetLeft - trackEl.offsetLeft : undefined
-    );
+    this.measureVisibleRange(reached);
   }
 
   /**
@@ -246,28 +259,34 @@ export class CarouselComponent {
       return;
     }
 
-    // Measured from the real slide offsets rather than derived from
-    // scrollWidth, so the flex gap cannot skew the result.
-    const slides = Array.from(trackEl.children) as HTMLElement[];
-    if (!slides.length) {
+    if (!trackEl.children.length) {
       return;
     }
 
-    const scrollLeft = trackEl.scrollLeft;
+    this.activeIndex.set(this.indexAtOffset(trackEl, trackEl.scrollLeft));
+    this.measureVisibleRange();
+  }
+
+  /**
+   * The slide sitting closest to a scroll offset.
+   *
+   * Measured from the real slide offsets rather than derived from scrollWidth,
+   * so the flex gap cannot skew the result.
+   */
+  private indexAtOffset(trackEl: HTMLElement, scrollLeft: number): number {
+    const slides = Array.from(trackEl.children) as HTMLElement[];
+
     let closest = 0;
     let smallestDelta = Number.POSITIVE_INFINITY;
 
     slides.forEach((slide, index) => {
-      const delta = Math.abs(
-        slide.offsetLeft - trackEl.offsetLeft - scrollLeft
-      );
+      const delta = Math.abs(slide.offsetLeft - trackEl.offsetLeft - scrollLeft);
       if (delta < smallestDelta) {
         smallestDelta = delta;
         closest = index;
       }
     });
 
-    this.activeIndex.set(closest);
-    this.measureVisibleRange();
+    return closest;
   }
 }

--- a/apps/tehwolfde/src/app/components/nav/mobile/mobile.component.scss
+++ b/apps/tehwolfde/src/app/components/nav/mobile/mobile.component.scss
@@ -23,6 +23,14 @@
   color: global.$linkcolor;
 }
 
+// Material sizes icon buttons at 40px, below the 48px minimum touch target.
+// Set through its own token rather than by overriding width and height: those
+// are declared on .mat-mdc-icon-button itself, so a rule of equal specificity
+// would depend on stylesheet order to win.
+.mat-mdc-icon-button {
+  --mat-icon-button-state-layer-size: 48px;
+}
+
 .nav-logo {
   height: 20px;
   width: 20px;

--- a/apps/tehwolfde/src/app/i18n/language-switcher.component.html
+++ b/apps/tehwolfde/src/app/i18n/language-switcher.component.html
@@ -1,9 +1,13 @@
+<!-- No aria-label: it would replace the accessible name with text that does not
+     contain the visible "DE"/"EN", leaving voice control users with nothing to
+     say (WCAG 2.5.3). The visible code names the control; the description
+     carries the "switch language" context for screen reader users. -->
 <button
   mat-button
   class="language-button"
   type="button"
   (click)="translateService.toggle()"
-  [attr.aria-label]="'nav.switchLanguage' | translate"
+  [attr.aria-describedby]="describedById"
 >
   @if (translateService.nextLocale() === 'de') {
     <svg class="language-flag" viewBox="0 0 5 3" aria-hidden="true">
@@ -20,3 +24,6 @@
   }
   <span class="language-code">{{ translateService.nextLocale() }}</span>
 </button>
+<span [id]="describedById" class="cdk-visually-hidden">{{
+  'nav.switchLanguage' | translate
+}}</span>

--- a/apps/tehwolfde/src/app/i18n/language-switcher.component.scss
+++ b/apps/tehwolfde/src/app/i18n/language-switcher.component.scss
@@ -18,11 +18,10 @@
 
 // Material wraps projected content in .mdc-button__label, so centring the
 // button itself leaves flag and code stacked inside that wrapper. The label is
-// the element that has to become the flex row.
-//
-// ::ng-deep is required rather than belt and braces: the wrapper belongs to
-// MatButton's template, so it carries MatButton's scoping attribute and an
-// unpierced selector can never match it under emulated encapsulation.
+// the element that has to become the flex row. ::ng-deep is required rather
+// than belt and braces: the wrapper belongs to MatButton's template, so it
+// carries MatButton's scoping attribute and an unpierced selector can never
+// match it under emulated encapsulation.
 .language-button ::ng-deep .mdc-button__label {
   display: inline-flex;
   align-items: center;

--- a/apps/tehwolfde/src/app/i18n/language-switcher.component.scss
+++ b/apps/tehwolfde/src/app/i18n/language-switcher.component.scss
@@ -7,16 +7,23 @@
   align-items: center;
 }
 
+// 48px tall to match the icon buttons beside it: a mat-button defaults to 36px,
+// which is below the minimum touch target and left the switcher noticeably
+// smaller than the theme toggle it sits next to.
 .language-button {
-  min-width: 0;
-  padding: 0 8px;
+  min-width: 48px;
+  height: 48px;
+  padding: 0 10px;
 }
 
 // Material wraps projected content in .mdc-button__label, so centring the
 // button itself leaves flag and code stacked inside that wrapper. The label is
 // the element that has to become the flex row.
-.language-button ::ng-deep .mdc-button__label,
-.language-button .mdc-button__label {
+//
+// ::ng-deep is required rather than belt and braces: the wrapper belongs to
+// MatButton's template, so it carries MatButton's scoping attribute and an
+// unpierced selector can never match it under emulated encapsulation.
+.language-button ::ng-deep .mdc-button__label {
   display: inline-flex;
   align-items: center;
   gap: 6px;

--- a/apps/tehwolfde/src/app/i18n/language-switcher.component.spec.ts
+++ b/apps/tehwolfde/src/app/i18n/language-switcher.component.spec.ts
@@ -1,0 +1,105 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LanguageSwitcherComponent } from './language-switcher.component';
+import { TranslateService } from './translate.service';
+
+describe('LanguageSwitcherComponent', () => {
+  let fixture: ComponentFixture<LanguageSwitcherComponent>;
+  let translateService: TranslateService;
+
+  /** The button element the user actually clicks. */
+  function button(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('button');
+  }
+
+  function visibleCode(): string {
+    return (
+      fixture.nativeElement
+        .querySelector('.language-code')
+        ?.textContent?.trim() ?? ''
+    );
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LanguageSwitcherComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LanguageSwitcherComponent);
+    translateService = TestBed.inject(TranslateService);
+    fixture.detectChanges();
+  });
+
+  it('should offer the locale the user is not reading', () => {
+    // The control shows where a click leads, not where the user already is.
+    // Inverting this would silently label every switcher wrongly.
+    expect(translateService.locale()).toBe('en');
+    expect(visibleCode()).toBe('de');
+  });
+
+  it('should toggle the locale when clicked', () => {
+    button().click();
+    fixture.detectChanges();
+
+    expect(translateService.locale()).toBe('de');
+    expect(visibleCode()).toBe('en');
+
+    button().click();
+    fixture.detectChanges();
+
+    expect(translateService.locale()).toBe('en');
+    expect(visibleCode()).toBe('de');
+  });
+
+  it('should show the flag of the offered locale', () => {
+    const flagOf = () =>
+      fixture.nativeElement.querySelector('svg.language-flag');
+
+    expect(flagOf()).toBeTruthy();
+    const offeringGerman = flagOf().outerHTML;
+
+    button().click();
+    fixture.detectChanges();
+
+    // Different artwork per locale rather than one flag that never changes.
+    expect(flagOf().outerHTML).not.toBe(offeringGerman);
+  });
+
+  it('should keep the visible code inside the accessible name', () => {
+    // WCAG 2.5.3: an aria-label that omits the visible text leaves voice
+    // control users with no phrase that matches what they can see.
+    expect(button().getAttribute('aria-label')).toBeNull();
+    expect(visibleCode().length).toBeGreaterThan(0);
+  });
+
+  it('should describe the control without overriding its name', () => {
+    const describedBy = button().getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+
+    const description = fixture.nativeElement.querySelector(
+      `#${describedBy}`
+    ) as HTMLElement | null;
+    expect(description).toBeTruthy();
+    expect(description?.textContent?.trim()).toBe('nav.switchLanguage');
+  });
+
+  it('should give each instance its own description id', () => {
+    // Both nav variants render a switcher at once, so a fixed id would be
+    // duplicated and the second button would point at the first description.
+    const second = TestBed.createComponent(LanguageSwitcherComponent);
+    second.detectChanges();
+
+    const first = fixture.componentInstance.describedById;
+    expect(second.componentInstance.describedById).not.toBe(first);
+  });
+
+  it('should mark the flag as decorative', () => {
+    // The code beside it already names the language, so announcing the artwork
+    // would repeat it.
+    const flag = fixture.nativeElement.querySelector('svg.language-flag');
+    expect(flag.getAttribute('aria-hidden')).toBe('true');
+  });
+});

--- a/apps/tehwolfde/src/app/i18n/language-switcher.component.ts
+++ b/apps/tehwolfde/src/app/i18n/language-switcher.component.ts
@@ -4,6 +4,9 @@ import { MatButtonModule } from '@angular/material/button';
 import { TranslatePipe } from './translate.pipe';
 import { TranslateService } from './translate.service';
 
+/** Counter behind the per instance id of the visually hidden description. */
+let nextId = 0;
+
 /**
  * Toggles between the two locales, showing the flag of the one being offered
  * rather than the one in use.
@@ -23,4 +26,11 @@ import { TranslateService } from './translate.service';
 })
 export class LanguageSwitcherComponent {
   translateService = inject(TranslateService);
+
+  /**
+   * Ties the button to its visually hidden description. Both nav variants are
+   * in the DOM at once on every viewport, so a fixed id would be duplicated and
+   * the second instance would point at the first one's description.
+   */
+  readonly describedById = `language-switcher-description-${nextId++}`;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "22.1.5",
+  "version": "22.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "22.1.5",
+      "version": "22.1.6",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "22.0.6",
@@ -20,7 +20,7 @@
         "@angular/router": "22.0.8",
         "@ngx-formly/core": "7.1.0",
         "@ngx-formly/material": "7.1.0",
-        "@tehw0lf/mvc": "0.0.8",
+        "@tehw0lf/mvc": "0.0.11",
         "cartesian-product-generator": "1.1.1",
         "github-language-colors": "1.0.0",
         "rxjs": "7.8.2",
@@ -10208,9 +10208,9 @@
       }
     },
     "node_modules/@tehw0lf/mvc": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@tehw0lf/mvc/-/mvc-0.0.8.tgz",
-      "integrity": "sha512-YNIq7EZe4JVNQVr9pEE4HQrwFEnUHsQD12UThxwKMH0UDvIXjT+IYxn51aBVEzMs2p1V6z4OUzTYU0zvhpfPsg==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@tehw0lf/mvc/-/mvc-0.0.11.tgz",
+      "integrity": "sha512-6VXoxim7mLiCFd/yb9xBm0CN9yseTXTw3yr5whd8fg/kjkgIlDnV2coUlVkbaVkRZLJtOz96qR44AKTJ4UW/DQ==",
       "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "22.1.5",
+  "version": "22.1.6",
   "license": "MIT",
   "scripts": {
     "ng": "nx",
@@ -42,7 +42,7 @@
     "@angular/router": "22.0.8",
     "@ngx-formly/core": "7.1.0",
     "@ngx-formly/material": "7.1.0",
-    "@tehw0lf/mvc": "0.0.8",
+    "@tehw0lf/mvc": "0.0.11",
     "cartesian-product-generator": "1.1.1",
     "github-language-colors": "1.0.0",
     "rxjs": "7.8.2",


### PR DESCRIPTION
Addresses five review findings on #319, and picks up `@tehw0lf/mvc@0.0.11`.

## Accessibility

**Label in Name (WCAG 2.5.3).** The button had `aria-label="Switch language"` beside a visible `DE`/`EN`. The accessible name contained none of the visible text, so a voice control user saying "click DE" matched nothing. The visible code now *is* the name; the "switch language" context moved to an `aria-describedby` element.

That element's id is generated per instance: both nav variants render a switcher simultaneously on every viewport, so a fixed id would be duplicated and the second button would point at the first one's description.

**Touch targets.** The switcher was a 36px `mat-button`; the icon buttons beside it sat at Material's 40px default. Both are now 48px.

The icon buttons are raised via `--mat-icon-button-state-layer-size` rather than by setting `width`/`height` directly — Material declares those on `.mat-mdc-icon-button` itself, so an equally specific rule of mine only won or lost by stylesheet order. Verified in the browser: my first attempt silently did nothing.

## Correctness

**Dead selector.** `.language-button .mdc-button__label` (the non-`::ng-deep` half) can never match: the wrapper belongs to MatButton's template and carries MatButton's scoping attribute. Confirmed in the built bundle. Removing it makes the remaining `::ng-deep` visibly load-bearing, so it can't be deleted later as "deprecated cruft" without the flag and code silently stacking vertically.

**`scrollTo` at the end of the track** (pre-existing, not introduced by #319). It recorded the *requested* index while the browser clamps the real scroll, so `activeIndex` named a slide never reached and the next step back moved by the remainder instead of a full slide. The target is now clamped against the reachable offset, and the index derived from where the track actually lands. The nearest-slide search `onScroll` already contained is extracted as `indexAtOffset` rather than written twice.

## Tests

The switcher shipped with no spec, and neither nav spec referenced it — inverting the `nextLocale` ternary would have flipped the label site-wide with a green suite. Now covered, along with the accessible name, the per-instance id, the decorative flag, and the reachable-end regression.

71 → 79 unit tests.

## Verification

Measured in a real browser, not asserted from the source:

| Check | Result |
|---|---|
| accessible name | `"DE"` — the visible text, no `aria-label` |
| description | `"Switch language"` via `aria-describedby` |
| ids with two switchers mounted | `-0` / `-1`, unique |
| mobile row: menu / theme / switcher | 48px / 48px / 62×48 |
| flag and code | side by side, both at `centerY: 28` |

`nx run-many -t lint,test,build`: 0 errors, 79 tests. `npm run e2e`: **106/106**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved carousel behavior at the end of the available slides, keeping the active slide and backward navigation accurate.

- **Accessibility**
  - Enhanced language-switcher labeling for screen readers with clear, unique descriptions.
  - Preserved visible language codes and marked decorative flags appropriately.

- **Style**
  - Improved mobile navigation and language-switcher button sizing for easier touch interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->