### PR TITLE
fix(tehwolfde): stop focus scrolling from moving the carousels

### DIFF
--- a/apps/tehwolfde-e2e/src/home.spec.ts
+++ b/apps/tehwolfde-e2e/src/home.spec.ts
@@ -34,6 +34,52 @@ test.describe('tehwolfde Home', () => {
     await expect(lightButton.or(darkButton)).toBeVisible();
   });
 
+  // Focusing #main-content after NavigationEnd used to scroll the carousels:
+  // the browser reveals a focus target by scrolling every scroll container
+  // around it, which walked the first track on the page to its far end. On a
+  // phone the libraries section therefore arrived showing its last slide.
+  // The viewport comes from a fresh context rather than setViewportSize: the
+  // scroll only happens on the navigation that focuses main, so the page has to
+  // be laid out at phone width before it loads, not resized afterwards.
+  test('should start every carousel at its first slide on mobile', async ({
+    browser,
+    browserName
+  }) => {
+    // isMobile is a Chromium only option, and Chromium is where the offending
+    // focus scroll happens, so the other engines run the same check without it.
+    const context = await browser.newContext({
+      viewport: { width: 390, height: 844 },
+      ...(browserName === 'chromium'
+        ? { isMobile: true, hasTouch: true }
+        : {})
+    });
+
+    try {
+      const page = await context.newPage();
+      await page.goto('/');
+
+      await expect(
+        page.locator('[data-section] .carousel-track').first()
+      ).toBeVisible();
+
+      // The offending scroll is animated and starts shortly after load, so the
+      // tracks have to be read once they have settled. expect.poll would defeat
+      // the test: it retries until the condition holds and so passes on the
+      // first sample taken before the animation begins.
+      await page.waitForTimeout(5000);
+
+      const offsets = await page.evaluate(() =>
+        Array.from(
+          document.querySelectorAll('[data-section] .carousel-track')
+        ).map((track) => (track as HTMLElement).scrollLeft)
+      );
+
+      expect(offsets).toEqual([0, 0]);
+    } finally {
+      await context.close();
+    }
+  });
+
   test('should be responsive', async ({ page }) => {
     // Test desktop view
     await page.setViewportSize({ width: 1200, height: 800 });

--- a/apps/tehwolfde/src/app/app.component.ts
+++ b/apps/tehwolfde/src/app/app.component.ts
@@ -29,7 +29,12 @@ export class AppComponent {
       .pipe(filter((e) => e instanceof NavigationEnd), takeUntilDestroyed())
       .subscribe(() => {
         const main = document.getElementById('main-content');
-        main?.focus();
+        // preventScroll because focusing the main landmark is only meant to move
+        // the reading position for keyboard and screen reader users. Without it
+        // the browser scrolls every scrollable ancestor and descendant to reveal
+        // the target, which walks the first carousel track on the page to its
+        // far end — the libraries section arrived showing its last slide.
+        main?.focus({ preventScroll: true });
       });
 
     // Exposes the site level tools to agents where the browser supports

--- a/apps/tehwolfde/src/app/i18n/language-switcher.component.scss
+++ b/apps/tehwolfde/src/app/i18n/language-switcher.component.scss
@@ -1,3 +1,5 @@
+@use '../../assets/styles/global';
+
 // mat-icon-button centres a 24px glyph, which neither an svg nor a text node
 // inherits, so the old label sat off centre next to the theme and GitHub icons.
 // A mat-button with explicit centring keeps flag and code on the same baseline
@@ -39,7 +41,11 @@
   flex: none;
 }
 
+// The code is the only text in the toolbar that Material colours itself, so
+// without this it rendered in the default button foreground while the nav links
+// and icons beside it use the site link colour.
 .language-code {
+  color: global.$linkcolor;
   font-size: 13px;
   font-weight: 500;
   letter-spacing: 0.04em;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "22.1.6",
+  "version": "22.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "22.1.6",
+      "version": "22.1.7",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "22.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "22.1.6",
+  "version": "22.1.7",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Libraries carousel scrolled to its last slide

On mobile the libraries carousel arrived showing its last slide, while the apps carousel correctly stayed on its first.

The carousel was not at fault. `AppComponent` focuses `#main-content` after every `NavigationEnd` (the skip-link target), and the browser reveals a focus target by scrolling **every** scroll container around it. Since `.carousel-track` sets `scroll-behavior: smooth`, the track animated its way to the maximum offset.

Instrumenting the running page confirmed it — the libraries track crept `2 → 12 → 36 → … → 650`, which is exactly its max scroll (`scrollWidth 1008 − clientWidth 358`), with **no `scrollIntoView` call in the trace**, so the carousel's own scrolling code never ran. The apps carousel escaped only because its track is 2728px wide, so the same nudge never reached the end.

Fix: `main?.focus({ preventScroll: true })`. Focusing the landmark is only meant to move the reading position for keyboard and screen reader users; it should not scroll anything.

## Language switcher colour

`.language-code` had no colour rule, so the DE/EN text fell back to Material's default button foreground while every nav item beside it uses `$linkcolor`. Both now compute to `rgb(232, 144, 63)`.

The flag stays. Flag + code avoids the country-vs-language ambiguity that affects flag-only switchers, and a two-letter code keeps the toggle a fixed width — full endonyms would resize the button on every click and shift the toolbar beside it.

## Testing

`lint`, `test`, `build` clean; all 108 e2e pass (Chromium + Firefox).

The regression test was verified in **both** directions: **2 failed with the fix reverted, 2 passed with it applied**. Worth calling out, because two earlier drafts of the test passed even without the fix and guarded nothing:

- `setViewportSize` + `goto` does not reproduce it — the page has to be laid out at phone width *before* it loads, so the test builds its own context.
- `expect.poll` actively defeated the test: it retries until the condition holds, so it passed on the first sample taken before the animated scroll began. Replaced with settle-then-assert.

Version bumped to 22.1.7 with `package-lock.json` synced, per the repo's CI artifact-naming requirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation accessibility by returning focus to the main content without unexpectedly changing scroll positions.
  - Fixed language switcher link colors for more consistent styling.
  - Resolved a mobile layout issue where carousel content could start at an incorrect scroll offset.

- **Tests**
  - Added mobile regression coverage for carousel positioning.

- **Chores**
  - Incremented the application version to 22.1.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->