### PR TITLE
feat(tehwolfde): globe and endonym language menu

### DIFF
--- a/apps/tehwolfde-e2e/src/home.spec.ts
+++ b/apps/tehwolfde-e2e/src/home.spec.ts
@@ -34,6 +34,56 @@ test.describe('tehwolfde Home', () => {
     await expect(lightButton.or(darkButton)).toBeVisible();
   });
 
+  test('should have language switcher', async ({ page }) => {
+    const mainNav = page.getByRole('navigation', { name: 'Main navigation' });
+    const trigger = mainNav.locator('button.language-button');
+
+    // The trigger reports the active locale rather than the one on offer.
+    await expect(trigger).toContainText('English');
+
+    await trigger.click();
+    const menu = page.locator('.mat-mdc-menu-panel');
+    await expect(menu).toBeVisible();
+
+    // Endonyms, so each language is recognisable to someone who cannot read
+    // the currently active one.
+    await expect(menu.getByRole('menuitemradio', { name: 'Deutsch' })).toBeVisible();
+    await menu.getByRole('menuitemradio', { name: 'Deutsch' }).click();
+
+    await expect(trigger).toContainText('Deutsch');
+    await expect(page.locator('h1')).toContainText('Willkommen');
+  });
+
+  // The endonyms differ in width, so a label sized to its content resized the
+  // button on every switch and shoved the GitHub link beside it sideways. jsdom
+  // does not lay text out, so the fixed box can only be verified here, against
+  // a real layout, by measuring the same element in both locales.
+  test('should not resize the language switcher when the locale changes', async ({
+    page
+  }) => {
+    const mainNav = page.getByRole('navigation', { name: 'Main navigation' });
+    const trigger = mainNav.locator('button.language-button');
+
+    const englishBox = await trigger.boundingBox();
+
+    await trigger.click();
+    await page
+      .locator('.mat-mdc-menu-panel')
+      .getByRole('menuitemradio', { name: 'Deutsch' })
+      .click();
+    await expect(trigger).toContainText('Deutsch');
+
+    const germanBox = await trigger.boundingBox();
+
+    expect(englishBox).not.toBeNull();
+    expect(germanBox).not.toBeNull();
+    expect(germanBox?.width).toBeCloseTo(englishBox?.width ?? 0, 1);
+    // The glyph and the first letter have to stay put too, not just the outer
+    // edges: Material centres the label, so a fixed width alone would still
+    // slide the text inside it.
+    expect(germanBox?.x).toBeCloseTo(englishBox?.x ?? 0, 1);
+  });
+
   // Focusing #main-content after NavigationEnd used to scroll the carousels:
   // the browser reveals a focus target by scrolling every scroll container
   // around it, which walked the first track on the page to its far end. On a

--- a/apps/tehwolfde-e2e/src/home.spec.ts
+++ b/apps/tehwolfde-e2e/src/home.spec.ts
@@ -77,11 +77,18 @@ test.describe('tehwolfde Home', () => {
 
     expect(englishBox).not.toBeNull();
     expect(germanBox).not.toBeNull();
-    expect(germanBox?.width).toBeCloseTo(englishBox?.width ?? 0, 1);
+
+    // A whole pixel of slack rather than toBeCloseTo's 0.05: engines round
+    // subpixel text metrics differently per locale, and this has to hold across
+    // every Playwright project. The regression it guards against moved the
+    // button by 6px, so the looser bound still catches it comfortably.
+    expect(Math.abs((germanBox?.width ?? 0) - (englishBox?.width ?? 0)))
+      .toBeLessThanOrEqual(1);
     // The glyph and the first letter have to stay put too, not just the outer
     // edges: Material centres the label, so a fixed width alone would still
     // slide the text inside it.
-    expect(germanBox?.x).toBeCloseTo(englishBox?.x ?? 0, 1);
+    expect(Math.abs((germanBox?.x ?? 0) - (englishBox?.x ?? 0)))
+      .toBeLessThanOrEqual(1);
   });
 
   // Focusing #main-content after NavigationEnd used to scroll the carousels:

--- a/apps/tehwolfde/src/app/i18n/language-switcher.component.html
+++ b/apps/tehwolfde/src/app/i18n/language-switcher.component.html
@@ -1,29 +1,44 @@
 <!-- No aria-label: it would replace the accessible name with text that does not
-     contain the visible "DE"/"EN", leaving voice control users with nothing to
-     say (WCAG 2.5.3). The visible code names the control; the description
-     carries the "switch language" context for screen reader users. -->
+     contain the visible endonym, leaving voice control users with nothing to
+     say (WCAG 2.5.3). The visible name of the active language names the
+     control; the description carries the "switch language" context for screen
+     reader users. -->
 <button
   mat-button
   class="language-button"
   type="button"
-  (click)="translateService.toggle()"
+  [matMenuTriggerFor]="languageMenu"
   [attr.aria-describedby]="describedById"
 >
-  @if (translateService.nextLocale() === 'de') {
-    <svg class="language-flag" viewBox="0 0 5 3" aria-hidden="true">
-      <rect width="5" height="1" y="0" fill="#000000" />
-      <rect width="5" height="1" y="1" fill="#dd0000" />
-      <rect width="5" height="1" y="2" fill="#ffce00" />
-    </svg>
-  } @else {
-    <svg class="language-flag" viewBox="0 0 19 10" aria-hidden="true">
-      <rect width="19" height="10" fill="#b22234" />
-      <path d="M0 1.5h19M0 3.5h19M0 5.5h19M0 7.5h19M0 9.5h19" stroke="#ffffff" />
-      <rect width="8" height="5.5" fill="#3c3b6e" />
-    </svg>
-  }
-  <span class="language-code">{{ translateService.nextLocale() }}</span>
+  <mat-icon class="language-globe" aria-hidden="true">language</mat-icon>
+  <span class="language-name">{{ translateService.currentEndonym() }}</span>
 </button>
 <span [id]="describedById" class="cdk-visually-hidden">{{
   'nav.switchLanguage' | translate
 }}</span>
+
+<mat-menu #languageMenu="matMenu" class="language-menu">
+  @for (locale of locales; track locale.code) {
+    <!-- menuitemradio rather than menuitem: the locales are one exclusive
+         choice, and aria-checked is what tells a screen reader which one is
+         active. The tick is its visual counterpart, so sighted and screen
+         reader users get the same information. -->
+    <button
+      mat-menu-item
+      type="button"
+      role="menuitemradio"
+      [attr.aria-checked]="translateService.locale() === locale.code"
+      [lang]="locale.code"
+      (click)="select(locale.code)"
+    >
+      @if (translateService.locale() === locale.code) {
+        <mat-icon class="language-check" aria-hidden="true">check</mat-icon>
+      } @else {
+        <!-- An empty box rather than no element at all, so the endonyms of the
+             unticked entries stay aligned with the ticked one. -->
+        <span class="language-check" aria-hidden="true"></span>
+      }
+      <span>{{ locale.endonym }}</span>
+    </button>
+  }
+</mat-menu>

--- a/apps/tehwolfde/src/app/i18n/language-switcher.component.scss
+++ b/apps/tehwolfde/src/app/i18n/language-switcher.component.scss
@@ -51,7 +51,7 @@
 // The name is the only text in the toolbar that Material colours itself, so
 // without this it rendered in the default button foreground while the nav links
 // and icons beside it use the site link colour.
-//
+
 // Endonyms differ in width, so a label sized to its content would resize the
 // button on every switch and shove the GitHub link beside it sideways. The
 // reservation is made here rather than on the button because Material centres
@@ -59,7 +59,7 @@
 // the outer edges still but still slide the text within them. Left aligning it
 // against a fixed box keeps the glyph and the first letter on the same spot
 // whatever locale is active.
-//
+
 // 10ch fits the longest endonym likely to be added. 1ch is the width of "0",
 // but these are proportional mixed case words, so the two do not correspond:
 // measured in this exact font, "Nederlands" is the widest realistic candidate

--- a/apps/tehwolfde/src/app/i18n/language-switcher.component.scss
+++ b/apps/tehwolfde/src/app/i18n/language-switcher.component.scss
@@ -11,7 +11,9 @@
 
 // 48px tall to match the icon buttons beside it: a mat-button defaults to 36px,
 // which is below the minimum touch target and left the switcher noticeably
-// smaller than the theme toggle it sits next to.
+// smaller than the theme toggle it sits next to. The width is a floor rather
+// than a fixed size because the label is an endonym whose length varies by
+// locale.
 .language-button {
   min-width: 48px;
   height: 48px;
@@ -31,24 +33,33 @@
   line-height: 1;
 }
 
-.language-flag {
-  display: block;
+// Sized down from the mat-icon default of 24px so the glyph matches the cap
+// height of the name beside it rather than towering over it.
+.language-globe {
   width: 20px;
-  height: 14px;
-  // The artwork carries its own colours, so it must not pick up the toolbar
-  // text colour the way a mat-icon would.
-  border-radius: 2px;
+  height: 20px;
+  font-size: 20px;
+  line-height: 1;
+  color: global.$linkcolor;
   flex: none;
 }
 
-// The code is the only text in the toolbar that Material colours itself, so
+// The menu entries are styled in styles.scss, not here: mat-menu renders into
+// the CDK overlay at the document root, outside this component's DOM, so no
+// scoped rule reaches them.
+
+// The name is the only text in the toolbar that Material colours itself, so
 // without this it rendered in the default button foreground while the nav links
 // and icons beside it use the site link colour.
-.language-code {
+//
+// Endonyms differ in width and change with the active locale, so the button has
+// to grow with its label instead of sitting at a fixed width; white-space keeps
+// a longer name on one line rather than wrapping inside the toolbar.
+.language-name {
   color: global.$linkcolor;
   font-size: 13px;
   font-weight: 500;
   letter-spacing: 0.04em;
-  text-transform: uppercase;
   line-height: 1;
+  white-space: nowrap;
 }

--- a/apps/tehwolfde/src/app/i18n/language-switcher.component.scss
+++ b/apps/tehwolfde/src/app/i18n/language-switcher.component.scss
@@ -11,9 +11,9 @@
 
 // 48px tall to match the icon buttons beside it: a mat-button defaults to 36px,
 // which is below the minimum touch target and left the switcher noticeably
-// smaller than the theme toggle it sits next to. The width is a floor rather
-// than a fixed size because the label is an endonym whose length varies by
-// locale.
+// smaller than the theme toggle it sits next to. The width follows from the
+// label, which reserves a fixed box of its own, so the button no longer changes
+// size when the locale changes.
 .language-button {
   min-width: 48px;
   height: 48px;
@@ -52,9 +52,20 @@
 // without this it rendered in the default button foreground while the nav links
 // and icons beside it use the site link colour.
 //
-// Endonyms differ in width and change with the active locale, so the button has
-// to grow with its label instead of sitting at a fixed width; white-space keeps
-// a longer name on one line rather than wrapping inside the toolbar.
+// Endonyms differ in width, so a label sized to its content would resize the
+// button on every switch and shove the GitHub link beside it sideways. The
+// reservation is made here rather than on the button because Material centres
+// the label inside .mdc-button__label: a fixed button width alone would hold
+// the outer edges still but still slide the text within them. Left aligning it
+// against a fixed box keeps the glyph and the first letter on the same spot
+// whatever locale is active.
+//
+// 10ch fits the longest endonym likely to be added. 1ch is the width of "0",
+// but these are proportional mixed case words, so the two do not correspond:
+// measured in this exact font, "Nederlands" is the widest realistic candidate
+// at 9.93ch and "Português" needs 8.86ch, which is why this is not the 9ch it
+// looks like it should be. Anything longer is truncated by the overflow rule
+// rather than being allowed to reflow the toolbar.
 .language-name {
   color: global.$linkcolor;
   font-size: 13px;
@@ -62,4 +73,8 @@
   letter-spacing: 0.04em;
   line-height: 1;
   white-space: nowrap;
+  min-width: 10ch;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/apps/tehwolfde/src/app/i18n/language-switcher.component.spec.ts
+++ b/apps/tehwolfde/src/app/i18n/language-switcher.component.spec.ts
@@ -1,3 +1,4 @@
+import { OverlayContainer } from '@angular/cdk/overlay';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -8,18 +9,45 @@ import { TranslateService } from './translate.service';
 describe('LanguageSwitcherComponent', () => {
   let fixture: ComponentFixture<LanguageSwitcherComponent>;
   let translateService: TranslateService;
+  let overlayContainer: OverlayContainer;
 
-  /** The button element the user actually clicks. */
-  function button(): HTMLButtonElement {
-    return fixture.nativeElement.querySelector('button');
+  /** The trigger element the user actually clicks. */
+  function trigger(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('button.language-button');
   }
 
-  function visibleCode(): string {
+  function visibleName(): string {
     return (
       fixture.nativeElement
-        .querySelector('.language-code')
+        .querySelector('.language-name')
         ?.textContent?.trim() ?? ''
     );
+  }
+
+  /** The menu renders into an overlay, outside the component's own DOM. */
+  function menuItems(): HTMLButtonElement[] {
+    return Array.from(
+      overlayContainer
+        .getContainerElement()
+        .querySelectorAll('button[mat-menu-item]')
+    );
+  }
+
+  /**
+   * The endonym of each entry, read from its own span rather than from the
+   * item's textContent: the tick is an icon font ligature, so its glyph name
+   * would otherwise be counted as text even though aria-hidden keeps it away
+   * from screen readers.
+   */
+  function menuEndonyms(): string[] {
+    return menuItems().map(
+      (i) => i.querySelector('span:not(.language-check)')?.textContent?.trim() ?? ''
+    );
+  }
+
+  function openMenu(): void {
+    trigger().click();
+    fixture.detectChanges();
   }
 
   beforeEach(async () => {
@@ -30,53 +58,100 @@ describe('LanguageSwitcherComponent', () => {
 
     fixture = TestBed.createComponent(LanguageSwitcherComponent);
     translateService = TestBed.inject(TranslateService);
+    overlayContainer = TestBed.inject(OverlayContainer);
     fixture.detectChanges();
   });
 
-  it('should offer the locale the user is not reading', () => {
-    // The control shows where a click leads, not where the user already is.
-    // Inverting this would silently label every switcher wrongly.
+  it('should show the active locale on the trigger', () => {
+    // Menu convention: the trigger reports the current state rather than the
+    // one a click would lead to, because the trigger only opens the menu.
     expect(translateService.locale()).toBe('en');
-    expect(visibleCode()).toBe('de');
+    expect(visibleName()).toBe('English');
   });
 
-  it('should toggle the locale when clicked', () => {
-    button().click();
+  it('should name each locale by its own endonym', () => {
+    openMenu();
+
+    // Endonyms, not translated names: they must stay recognisable to someone
+    // who cannot read the currently active locale.
+    expect(menuEndonyms()).toEqual(['English', 'Deutsch']);
+  });
+
+  it('should switch the locale when a menu entry is chosen', () => {
+    openMenu();
+    menuItems()[1].click();
     fixture.detectChanges();
 
     expect(translateService.locale()).toBe('de');
-    expect(visibleCode()).toBe('en');
+    expect(visibleName()).toBe('Deutsch');
 
-    button().click();
+    openMenu();
+    menuItems()[0].click();
     fixture.detectChanges();
 
     expect(translateService.locale()).toBe('en');
-    expect(visibleCode()).toBe('de');
+    expect(visibleName()).toBe('English');
   });
 
-  it('should show the flag of the offered locale', () => {
-    const flagOf = () =>
-      fixture.nativeElement.querySelector('svg.language-flag');
+  it('should offer every configured locale', () => {
+    // Adding a language is meant to be a registry edit alone, so the menu is
+    // driven by the list rather than by hardcoded entries.
+    openMenu();
 
-    expect(flagOf()).toBeTruthy();
-    const offeringGerman = flagOf().outerHTML;
+    expect(menuItems().length).toBe(translateService.locales.length);
+  });
 
-    button().click();
+  it('should mark the active locale as checked', () => {
+    openMenu();
+
+    const checked = () =>
+      menuItems().map((i) => i.getAttribute('aria-checked'));
+    expect(checked()).toEqual(['true', 'false']);
+
+    menuItems()[1].click();
     fixture.detectChanges();
+    openMenu();
 
-    // Different artwork per locale rather than one flag that never changes.
-    expect(flagOf().outerHTML).not.toBe(offeringGerman);
+    expect(checked()).toEqual(['false', 'true']);
   });
 
-  it('should keep the visible code inside the accessible name', () => {
+  it('should expose the locale choice as an exclusive selection', () => {
+    // menuitemradio is what conveys "one of these is active" to a screen
+    // reader; plain menuitems would announce the tick as decoration only.
+    openMenu();
+
+    for (const item of menuItems()) {
+      expect(item.getAttribute('role')).toBe('menuitemradio');
+    }
+  });
+
+  it('should tag each entry with its own language', () => {
+    // Without lang, a screen reader reads "Deutsch" with English phonetics.
+    openMenu();
+
+    expect(menuItems().map((i) => i.getAttribute('lang'))).toEqual([
+      'en',
+      'de'
+    ]);
+  });
+
+  it('should report the menu expanded state on the trigger', () => {
+    expect(trigger().getAttribute('aria-expanded')).toBe('false');
+
+    openMenu();
+
+    expect(trigger().getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('should keep the visible name inside the accessible name', () => {
     // WCAG 2.5.3: an aria-label that omits the visible text leaves voice
     // control users with no phrase that matches what they can see.
-    expect(button().getAttribute('aria-label')).toBeNull();
-    expect(visibleCode().length).toBeGreaterThan(0);
+    expect(trigger().getAttribute('aria-label')).toBeNull();
+    expect(visibleName().length).toBeGreaterThan(0);
   });
 
   it('should describe the control without overriding its name', () => {
-    const describedBy = button().getAttribute('aria-describedby');
+    const describedBy = trigger().getAttribute('aria-describedby');
     expect(describedBy).toBeTruthy();
 
     const description = fixture.nativeElement.querySelector(
@@ -88,7 +163,7 @@ describe('LanguageSwitcherComponent', () => {
 
   it('should give each instance its own description id', () => {
     // Both nav variants render a switcher at once, so a fixed id would be
-    // duplicated and the second button would point at the first description.
+    // duplicated and the second trigger would point at the first description.
     const second = TestBed.createComponent(LanguageSwitcherComponent);
     second.detectChanges();
 
@@ -96,10 +171,10 @@ describe('LanguageSwitcherComponent', () => {
     expect(second.componentInstance.describedById).not.toBe(first);
   });
 
-  it('should mark the flag as decorative', () => {
-    // The code beside it already names the language, so announcing the artwork
+  it('should mark the globe as decorative', () => {
+    // The name beside it already names the language, so announcing the icon
     // would repeat it.
-    const flag = fixture.nativeElement.querySelector('svg.language-flag');
-    expect(flag.getAttribute('aria-hidden')).toBe('true');
+    const globe = fixture.nativeElement.querySelector('.language-globe');
+    expect(globe.getAttribute('aria-hidden')).toBe('true');
   });
 });

--- a/apps/tehwolfde/src/app/i18n/language-switcher.component.ts
+++ b/apps/tehwolfde/src/app/i18n/language-switcher.component.ts
@@ -1,36 +1,46 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
 
 import { TranslatePipe } from './translate.pipe';
-import { TranslateService } from './translate.service';
+import { Locale, TranslateService } from './translate.service';
 
 /** Counter behind the per instance id of the visually hidden description. */
 let nextId = 0;
 
 /**
- * Toggles between the two locales, showing the flag of the one being offered
- * rather than the one in use.
+ * Opens a menu of the available locales, each named by its own endonym.
  *
- * The flags are inline SVG instead of regional indicator emoji: emoji need a
- * colour emoji font, which plain Linux installs frequently lack, and the glyph
- * degrades to tofu boxes rather than to the letter pair it falls back to on
- * Windows. The locale code sits next to the flag so the control still reads as
- * a language switch when the artwork is too small to identify.
+ * A globe rather than flags: a flag names a country, not a language, so the
+ * artwork is wrong wherever the two do not line up (English is not the United
+ * States) and becomes a political choice as soon as a language is spoken in
+ * several countries. The globe carries no such claim and needs no per locale
+ * artwork when a language is added.
+ *
+ * The trigger shows the active locale, following the usual menu convention that
+ * the trigger reports the current state and the choices live inside.
  */
 @Component({
   selector: 'tehw0lf-language-switcher',
   templateUrl: './language-switcher.component.html',
   styleUrls: ['./language-switcher.component.scss'],
-  imports: [MatButtonModule, TranslatePipe],
+  imports: [MatButtonModule, MatIconModule, MatMenuModule, TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class LanguageSwitcherComponent {
   translateService = inject(TranslateService);
 
+  readonly locales = this.translateService.locales;
+
   /**
-   * Ties the button to its visually hidden description. Both nav variants are
+   * Ties the trigger to its visually hidden description. Both nav variants are
    * in the DOM at once on every viewport, so a fixed id would be duplicated and
    * the second instance would point at the first one's description.
    */
   readonly describedById = `language-switcher-description-${nextId++}`;
+
+  select(locale: Locale): void {
+    this.translateService.setLocale(locale);
+  }
 }

--- a/apps/tehwolfde/src/app/i18n/translate.service.ts
+++ b/apps/tehwolfde/src/app/i18n/translate.service.ts
@@ -5,12 +5,31 @@ import { catchError, of, switchMap } from 'rxjs';
 
 export type Locale = 'en' | 'de';
 
+/**
+ * The locales on offer, in the order the switcher lists them.
+ *
+ * Endonyms rather than translated names: someone looking for their language
+ * recognises it in its own spelling regardless of which locale is currently
+ * active, so the menu stays usable even when the user cannot read the UI it is
+ * rendered in. For the same reason these are not translation keys — they must
+ * not change with the active locale.
+ *
+ * Adding a language means adding an entry here and an `assets/i18n/<code>.json`
+ * file; the switcher picks it up without further changes.
+ */
+export const LOCALES: readonly { code: Locale; endonym: string }[] = [
+  { code: 'en', endonym: 'English' },
+  { code: 'de', endonym: 'Deutsch' }
+] as const;
+
 @Injectable({ providedIn: 'root' })
 export class TranslateService {
   private http = inject(HttpClient);
 
   locale = signal<Locale>('en');
   private translations = signal<Record<string, string>>({});
+
+  readonly locales = LOCALES;
 
   constructor() {
     toObservable(this.locale)
@@ -19,17 +38,20 @@ export class TranslateService {
   }
 
   /**
-   * The locale the switcher offers, which is the one the user is not currently
-   * reading. Both nav variants render the same control, so the label lives here
-   * rather than being duplicated as a ternary in two templates.
+   * The active locale's own name, shown on the switcher trigger. Both nav
+   * variants render the same control, so the label lives here rather than being
+   * duplicated in two templates.
    */
-  nextLocale = computed<Locale>(() => (this.locale() === 'en' ? 'de' : 'en'));
+  currentEndonym = computed<string>(
+    () =>
+      LOCALES.find((l) => l.code === this.locale())?.endonym ?? this.locale()
+  );
 
   translate(key: string): string {
     return this.translations()[key] ?? key;
   }
 
-  toggle(): void {
-    this.locale.update((l) => (l === 'en' ? 'de' : 'en'));
+  setLocale(locale: Locale): void {
+    this.locale.set(locale);
   }
 }

--- a/apps/tehwolfde/src/styles.scss
+++ b/apps/tehwolfde/src/styles.scss
@@ -67,6 +67,20 @@ body.light {
   color: global.$linkcolor !important;
 }
 
+// The tick on the active language and the empty box standing in for it on the
+// others. Both need the same footprint or the endonyms would not line up. This
+// lives here rather than in the switcher's own styles because mat-menu renders
+// into the CDK overlay at the document root, out of reach of a scoped rule.
+.language-check {
+  width: 18px;
+  height: 18px;
+  font-size: 18px;
+  line-height: 1;
+  margin-right: 8px;
+  flex: none;
+  color: global.$linkcolor;
+}
+
 body.dark .mat-mdc-menu-panel {
   background-color: #222222;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "22.1.9",
+  "version": "22.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "22.1.9",
+      "version": "22.1.10",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "22.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "22.1.8",
+  "version": "22.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "22.1.8",
+      "version": "22.1.9",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "22.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tehw0lf",
-  "version": "22.1.7",
+  "version": "22.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tehw0lf",
-      "version": "22.1.7",
+      "version": "22.1.8",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "22.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "22.1.8",
+  "version": "22.1.9",
   "license": "MIT",
   "scripts": {
     "ng": "nx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "22.1.7",
+  "version": "22.1.8",
   "license": "MIT",
   "scripts": {
     "ng": "nx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tehw0lf",
-  "version": "22.1.9",
+  "version": "22.1.10",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Why

The switcher showed a flag and a locale code. A flag names a country, not a language: the US flag stood for English even though the two do not line up, and picking artwork becomes a political choice as soon as a language is spoken in several countries (Spanish → Spain or Mexico?). The globe carries no such claim and needs no new artwork when a language is added.

With more locales planned, a two-way toggle no longer fits either, so the control becomes a menu.

## What changed

- **Globe + endonym instead of flag + code.** The trigger reports the *active* locale, following the usual menu convention that the trigger shows current state and the choices live inside.
- **Endonyms rather than translated names** ("Deutsch", not "German"), so a language stays recognisable to someone who cannot read the currently active UI language. For the same reason they are not translation keys — they must not change with the active locale.
- **Single locale registry** in `translate.service.ts`. Adding a language is one entry plus its `assets/i18n/<code>.json`; the switcher picks it up with no further changes. `nextLocale`/`toggle()` were wired to exactly two locales and are replaced by `currentEndonym` and `setLocale()`.
- **Fixed label width**, so the button no longer resizes on every switch and shoves the GitHub link beside it sideways by 6px.

## Accessibility

The existing decisions were kept deliberately, not dropped in the rewrite:

- No `aria-label` on the trigger — the visible name carries the accessible name (WCAG 2.5.3, label in name), it is just "Deutsch" now instead of "DE". The visually hidden "switch language" description and its per-instance id are unchanged, since both nav variants are in the DOM at once.
- Menu entries are `menuitemradio` with `aria-checked`, so the exclusive choice reaches screen readers rather than the tick being decoration only.
- Each entry carries `lang`, so "Deutsch" is not read with English phonetics.

## Notes on two implementation details

**`10ch`, not the `9ch` the longest current endonym suggests.** `1ch` is the width of "0", but endonyms are proportional mixed case words, so the two do not correspond. Measured in this exact font (Roboto 13px/500, `letter-spacing: 0.04em`): "Nederlands" needs 9.93ch and "Português" 8.86ch, so `9ch` would have clipped the very languages likely to be added next.

**The width reservation sits on the label, not the button.** Material centres the content of `.mdc-button__label`, so a fixed button width alone would hold the outer edges still while the glyph and first letter kept sliding inside them.

## Testing

`lint`, `test`, `build` and `e2e` all pass.

- 84 unit tests — the switcher's own grew from 7 to 12, covering the menu, the checked state, the roles and the `lang` tags.
- 112 e2e (from 108). The switcher had no e2e coverage before; there is now one for the flow itself and one for the width.
- The width is asserted in e2e rather than in Jest because jsdom does not lay text out — `getComputedStyle` simply returned `""`. I verified the test actually bites: with `min-width` temporarily removed it fails showing the exact regression (92.6px → 98.6px).

Version bumped to 22.1.9 with the lockfile in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the direct language toggle with a menu listing all available languages.
  * The switcher now shows the current language name with a globe icon.
  * Added selection indicators and improved accessibility semantics.
  * Language names remain aligned and readable when switching locales.

* **Tests**
  * Added coverage for language selection, accessibility, and layout stability.

* **Chores**
  * Updated the application version to 22.1.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->